### PR TITLE
fix grid tests for 54 ranks 

### DIFF
--- a/fv3core/tests/savepoint/translate/overrides/standard.yaml
+++ b/fv3core/tests/savepoint/translate/overrides/standard.yaml
@@ -119,12 +119,3 @@ Tracer2D1L:
    max_error: 1e-9
  - backend: gtc:cuda
    max_error: 1e-9
-
-DivgDel6:
- - max_error: 3e-13 # 48_6ranks
-
-DxDy:
- - max_error: 2e-13 # 48_6ranks
-
-EdgeFactors:
- - max_error: 2e-12 # 48_6ranks

--- a/fv3core/tests/savepoint/translate/overrides/standard.yaml
+++ b/fv3core/tests/savepoint/translate/overrides/standard.yaml
@@ -119,3 +119,12 @@ Tracer2D1L:
    max_error: 1e-9
  - backend: gtc:cuda
    max_error: 1e-9
+
+DivgDel6:
+ - max_error: 3e-13 # 48_6ranks
+
+DxDy:
+ - max_error: 2e-13 # 48_6ranks
+
+EdgeFactors:
+ - max_error: 2e-12 # 48_6ranks

--- a/fv3core/tests/savepoint/translate/translate_grid.py
+++ b/fv3core/tests/savepoint/translate/translate_grid.py
@@ -924,12 +924,9 @@ class TranslateTrigSg(ParallelTranslateGrid):
 
 
 class TranslateAAMCorrection(ParallelTranslateGrid):
-    # NOTE THIS TESTS is DISABLED
-    # TODO investiage failures on c48_6ranks_standard
-    # to enable, import in translate/__init__.py file
     def __init__(self, rank_grids):
         super().__init__(rank_grids)
-        self.max_error = 3e-14
+        self.max_error = 1e-14
         self.near_zero = 1e-14
         self.ignore_near_zero_errors = {"l2c_v": True, "l2c_u": True}
 


### PR DESCRIPTION
### Purpose
To have the regressions-cron test in CI passing, specifically getting the new grid tests to work for c12_54ranks_standard. 
* GnomonicGrid and MirrorGrid tests run on the global tile and are changed to be done with. numpy only (no quantities needed). 
