### PR TITLE
Allow objects with storage attribute as call arguments to FrozenStencil

### DIFF
--- a/fv3core/fv3core/stencils/dyn_core.py
+++ b/fv3core/fv3core/stencils/dyn_core.py
@@ -594,12 +594,12 @@ class AcousticDynamics:
                 )
                 self.riem_solver_c(
                     dt2,
-                    state.cappa,
+                    state.cappa_quantity,
                     state.ptop,
                     state.phis,
                     state.ws3,
                     state.ptc,
-                    state.q_con,
+                    state.q_con_quantity,
                     state.delpc,
                     state.gz,
                     state.pkc,

--- a/fv3core/fv3core/utils/stencil.py
+++ b/fv3core/fv3core/utils/stencil.py
@@ -201,6 +201,9 @@ class FrozenStencil:
         *args,
         **kwargs,
     ) -> None:
+        args_list = list(args)
+        _convert_quantities_to_storage(args_list, kwargs)
+        args = tuple(args_list)
         if self.stencil_config.validate_args:
             if __debug__ and "origin" in kwargs:
                 raise TypeError("origin cannot be passed to FrozenStencil call")
@@ -275,6 +278,19 @@ class FrozenStencil:
             and bool(field_info[field_name].access & gt4py.definitions.AccessKind.WRITE)
         ]
         return write_fields
+
+
+def _convert_quantities_to_storage(args, kwargs):
+    for i, arg in enumerate(args):
+        try:
+            args[i] = arg.storage
+        except AttributeError:
+            pass
+    for name, arg in kwargs.items():
+        try:
+            kwargs[name] = arg.storage
+        except AttributeError:
+            pass
 
 
 class GridIndexing:


### PR DESCRIPTION
This PR modifies FrozenStencil so that it checks for a `.storage` attribute and uses that instead when called.