### PR TITLE
Test all packages when non-subproject files change

### DIFF
--- a/changed_from_main.py
+++ b/changed_from_main.py
@@ -89,10 +89,16 @@ def changed(dirname) -> bool:
     return unstaged_files(dirname) or staged_files_changed(dirname)
 
 
+def top_level_files_changed() -> bool:
+    exclude_args = [f":!{dirname}/*" for dirname in get_dependencies().keys()]
+    result = subprocess.check_output(["git", "diff", "main", "."] + exclude_args)
+    return len(result) > 0
+
+
 if __name__ == "__main__":
     subdir_dependencies = get_dependencies()
     args = parse_args(subdir_dependencies)
-    if changed(args.project_name):
+    if changed(args.project_name) or top_level_files_changed():
         print("true")
     else:
         for dependency_subdir in subdir_dependencies[args.project_name]:


### PR DESCRIPTION
This PR updates changed_from_main.py so it prints "true" if any non-subproject files change.