### PR TITLE
stop re-downloading of data on gsutil fail

### DIFF
--- a/fv3core/Makefile
+++ b/fv3core/Makefile
@@ -164,7 +164,7 @@ push_python_regressions:
 
 get_test_data:
 	if [ ! -f "$(TEST_DATA_HOST)/input.nml" ] || \
-	[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt) -" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
+	[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt -)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
 	rm -rf $(TEST_DATA_HOST) && \
 	$(MAKE) sync_test_data && \
 	$(MAKE) unpack_test_data ;\

--- a/fv3core/Makefile
+++ b/fv3core/Makefile
@@ -164,7 +164,7 @@ push_python_regressions:
 
 get_test_data:
 	if [ ! -f "$(TEST_DATA_HOST)/input.nml" ] || \
-	[ "$$(gsutil cat $(DATA_BUCKET)md5sums.txt)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
+	[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt) -" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
 	rm -rf $(TEST_DATA_HOST) && \
 	$(MAKE) sync_test_data && \
 	$(MAKE) unpack_test_data ;\

--- a/fv3gfs-physics/Makefile
+++ b/fv3gfs-physics/Makefile
@@ -47,7 +47,7 @@ unpack_test_data:
 
 get_test_data:
 	if [ ! -f "$(TEST_DATA_HOST)/input.nml" ] || \
-	[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt) -" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
+	[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt -)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
 	rm -rf $(TEST_DATA_HOST) && \
 	$(MAKE) sync_test_data && \
 	$(MAKE) unpack_test_data ;\

--- a/fv3gfs-physics/Makefile
+++ b/fv3gfs-physics/Makefile
@@ -47,7 +47,7 @@ unpack_test_data:
 
 get_test_data:
 	if [ ! -f "$(TEST_DATA_HOST)/input.nml" ] || \
-	[ "$$(gsutil cat $(DATA_BUCKET)md5sums.txt)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
+	[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt) -" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
 	rm -rf $(TEST_DATA_HOST) && \
 	$(MAKE) sync_test_data && \
 	$(MAKE) unpack_test_data ;\


### PR DESCRIPTION
use gsutil cp - rather than gsutil cat because it has a checksum and safety, while gsutil cat is apparently the wild west.