### PR TITLE
parallel and sequential tests cache compiled stencil to the same folder

### DIFF
--- a/dsl/pace/dsl/stencil.py
+++ b/dsl/pace/dsl/stencil.py
@@ -170,6 +170,11 @@ class FrozenStencil:
         stencil_function = gtscript.stencil
         stencil_kwargs = {**self.stencil_config.stencil_kwargs}
 
+        # added because future stencil provides this information and
+        # we want to be consistent with the naming whether we are
+        # running in parallel or not (so we use the same cache)
+        stencil_kwargs["name"] = func.__module__ + "." + func.__name__
+
         # Enable distributed compilation if running in parallel
         if MPI is not None and MPI.COMM_WORLD.Get_size() > 1:
             stencil_function = future_stencil

--- a/dsl/pace/dsl/stencil.py
+++ b/dsl/pace/dsl/stencil.py
@@ -170,15 +170,15 @@ class FrozenStencil:
         stencil_function = gtscript.stencil
         stencil_kwargs = {**self.stencil_config.stencil_kwargs}
 
-        # added because future stencil provides this information and
-        # we want to be consistent with the naming whether we are
-        # running in parallel or not (so we use the same cache)
-        stencil_kwargs["name"] = func.__module__ + "." + func.__name__
-
         # Enable distributed compilation if running in parallel
         if MPI is not None and MPI.COMM_WORLD.Get_size() > 1:
             stencil_function = future_stencil
             stencil_kwargs["wrapper"] = self
+        else:
+            # future stencil provides this information and
+            # we want to be consistent with the naming whether we are
+            # running in parallel or not (so we use the same cache)
+            stencil_kwargs["name"] = func.__module__ + "." + func.__name__
 
         if skip_passes and self.stencil_config.is_gtc_backend:
             stencil_kwargs["skip_passes"] = skip_passes

--- a/fv3core/tests/main/test_stencil_wrapper.py
+++ b/fv3core/tests/main/test_stencil_wrapper.py
@@ -220,7 +220,10 @@ def test_frozen_stencil_kwargs_passed_to_init(
             externals={},
         )
     mock_stencil.assert_called_once_with(
-        definition=copy_stencil, externals={}, **config.stencil_kwargs
+        definition=copy_stencil,
+        externals={},
+        name="main.test_stencil_wrapper.copy_stencil",
+        **config.stencil_kwargs,
     )
 
 


### PR DESCRIPTION
setting the gtscript.stencil "name" argument to the funcs module + name, so that whether or not a future stencil is used, the compiled stencil ends up in the same cache file, so we don't have to run multiple versions of the code to generate the cache, and we can keep the file count low (or the daint inode limit). 