### PR TITLE
init baroclinic gpu

### DIFF
--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -78,7 +78,7 @@ fi
 # If the backend is a GTC backend we fetch the caches
 if [[ $backend != *numpy* ]];then
     echo "Fetching for exisintg gt_caches"
-    . ${jenkins_dir}/actions/fetch_caches.sh $backend $experiment
+    . ${JENKINS_DIR}/actions/fetch_caches.sh $backend $experiment
 fi
 
 # load machine dependent environment

--- a/fv3core/.jenkins/jenkins.sh
+++ b/fv3core/.jenkins/jenkins.sh
@@ -78,7 +78,7 @@ fi
 # If the backend is a GTC backend we fetch the caches
 if [[ $backend != *numpy* ]];then
     echo "Fetching for exisintg gt_caches"
-    . ${jenkins_dir}/actions/fetch_caches.sh $backend $experiment
+    . ${JENKINS_DIR}/actions/fetch_caches.sh $backend $experiment
 fi
 
 # load machine dependent environment

--- a/fv3core/fv3core/initialization/baroclinic.py
+++ b/fv3core/fv3core/initialization/baroclinic.py
@@ -425,8 +425,8 @@ def init_baroclinic_state(
     Create a DycoreState object with quantities initialized to the Jablonowski &
     Williamson baroclinic test case perturbation applied to the cubed sphere grid.
     """
-
-    shape = (*metric_terms.lat.data.shape[0:2], metric_terms.ak.data.shape[0])
+    sample_quantity = metric_terms.lat
+    shape = (*sample_quantity.data.shape[0:2], metric_terms.ak.data.shape[0])
     nx, ny, nz = local_compute_size(shape)
     numpy_dict = {}
     for _field in fields(DycoreState):
@@ -517,15 +517,13 @@ def init_baroclinic_state(
         make_nh=(not hydrostatic),
     )
     state = DycoreState.init_from_numpy_arrays(
-        numpy_state.__dict__, metric_terms.quantity_factory
+        numpy_state.__dict__,
+        metric_terms.quantity_factory,
+        sample_quantity.metadata.gt4py_backend,
     )
 
     comm.halo_update(state.phis_quantity, n_points=nhalo)
 
     comm.vector_halo_update(state.u_quantity, state.v_quantity, n_points=nhalo)
-    for i in range(state.u.data.shape[0]):
-        for j in range(state.u.data.shape[0]):
-            print(
-                "BADNESS", i, j, state.u.data[i, j, 0], state.u_quantity.data[i, j, 0]
-            )
+
     return state

--- a/fv3core/fv3core/initialization/baroclinic.py
+++ b/fv3core/fv3core/initialization/baroclinic.py
@@ -414,6 +414,15 @@ def compute_slices(nx, ny):
     return islice, jslice, slice_3d, slice_2d
 
 
+def empty_numpy_dycore_state(shape):
+    numpy_dict = {}
+    for _field in fields(DycoreState):
+        if "dims" in _field.metadata.keys():
+            numpy_dict[_field.name] = np.zeros(shape[: len(_field.metadata["dims"])])
+    numpy_state = SimpleNamespace(**numpy_dict)
+    return numpy_state
+
+
 def init_baroclinic_state(
     metric_terms: MetricTerms,
     adiabatic: bool,
@@ -428,11 +437,7 @@ def init_baroclinic_state(
     sample_quantity = metric_terms.lat
     shape = (*sample_quantity.data.shape[0:2], metric_terms.ak.data.shape[0])
     nx, ny, nz = local_compute_size(shape)
-    numpy_dict = {}
-    for _field in fields(DycoreState):
-        if "dims" in _field.metadata.keys():
-            numpy_dict[_field.name] = np.zeros(shape[: len(_field.metadata["dims"])])
-    numpy_state = SimpleNamespace(**numpy_dict)
+    numpy_state = empty_numpy_dycore_state(shape)
     # Initializing to values the Fortran does for easy comparison
     numpy_state.delp[:] = 1e30
     numpy_state.delp[:nhalo, :nhalo] = 0.0

--- a/fv3core/fv3core/initialization/baroclinic.py
+++ b/fv3core/fv3core/initialization/baroclinic.py
@@ -456,10 +456,6 @@ def init_baroclinic_state(
     # to accomodate averaging over shifted calculations on the grid
     _, _, slice_3d_buffer, slice_2d_buffer = compute_slices(nx + 1, ny + 1)
 
-    # TODO: It would be neat to use <quantity>.view here rather than slices
-    # But doesn't work with all numpy operations, would need to either
-    # support some features or change the calculations
-    # asarray was added to allow gpu operations, there are other solutions
     setup_pressure_fields(
         eta=eta,
         eta_v=eta_v,

--- a/fv3core/fv3core/initialization/dycore_state.py
+++ b/fv3core/fv3core/initialization/dycore_state.py
@@ -325,7 +325,7 @@ class DycoreState:
                     origin=quantity_factory._sizer.get_origin(dims),
                     extent=quantity_factory._sizer.get_extent(dims),
                     gt4py_backend=backend,
-                ).data  # TODO remove .data when using only Quantities
+                ).storage  # TODO remove .storage when using only Quantities
         state = cls(**dict_state, quantity_factory=quantity_factory)
         return state
 

--- a/fv3core/fv3core/initialization/dycore_state.py
+++ b/fv3core/fv3core/initialization/dycore_state.py
@@ -307,7 +307,7 @@ class DycoreState:
         return cls(**initial_storages, quantity_factory=quantity_factory)
 
     @classmethod
-    def init_from_numpy_arrays(cls, dict_of_numpy_arrays, quantity_factory):
+    def init_from_numpy_arrays(cls, dict_of_numpy_arrays, quantity_factory, backend):
         field_names = [_field.name for _field in fields(cls)]
         for variable_name, data in dict_of_numpy_arrays.items():
             if variable_name not in field_names:
@@ -324,6 +324,7 @@ class DycoreState:
                     _field.metadata["units"],
                     origin=quantity_factory._sizer.get_origin(dims),
                     extent=quantity_factory._sizer.get_extent(dims),
+                    gt4py_backend=backend,
                 ).data  # TODO remove .data when using only Quantities
         state = cls(**dict_state, quantity_factory=quantity_factory)
         return state

--- a/fv3core/fv3core/initialization/dycore_state.py
+++ b/fv3core/fv3core/initialization/dycore_state.py
@@ -308,20 +308,24 @@ class DycoreState:
 
     @classmethod
     def init_from_numpy_arrays(cls, dict_of_numpy_arrays, quantity_factory):
-        state = cls.init_empty(quantity_factory)
         field_names = [_field.name for _field in fields(cls)]
         for variable_name, data in dict_of_numpy_arrays.items():
             if variable_name not in field_names:
                 raise KeyError(
                     variable_name + " is provided, but not part of the dycore state"
                 )
-            getattr(state, variable_name).data[:] = data
-        for field_name in field_names:
-            if field_name not in dict_of_numpy_arrays.keys():
-                raise KeyError(
-                    field_name
-                    + " is not included in the provided dictionary of numpy arrays"
-                )
+        dict_state = {}
+        for _field in fields(cls):
+            if "dims" in _field.metadata.keys():
+                dims = _field.metadata["dims"]
+                dict_state[_field.name] = fv3util.Quantity(
+                    dict_of_numpy_arrays[_field.name],
+                    dims,
+                    _field.metadata["units"],
+                    origin=quantity_factory._sizer.get_origin(dims),
+                    extent=quantity_factory._sizer.get_extent(dims),
+                ).data  # TODO remove .data when using only Quantities
+        state = cls(**dict_state, quantity_factory=quantity_factory)
         return state
 
     @classmethod


### PR DESCRIPTION
On GPU the initilized state was actually all 0s, as the effort to keep the code from crashing on GPU actually entirely separated the gpu arrays from the cpu arrays. It is possible to pass cupy arrays (the state.quantity.data instead of the state.storage.data, which is a memory view and cannot be sliced) in and still do it this way, but this requires modifying almost all the lines of math to be cupy friendly (e.g. cp.asarray wrappers around many statements). Instead, we compute on the cpu in numpy, and from that create a DycoreState. 
This means we won't use the quantity.view feature to slice unless we revisit using a a DycoreState initialized with 0's to start with