### PR TITLE
Allow relative path in install virtualenv

### DIFF
--- a/.jenkins/install_virtualenv.sh
+++ b/.jenkins/install_virtualenv.sh
@@ -20,7 +20,7 @@ echo "pace path is ${pace_dir}"
 if [ -z "${GT4PY_VERSION}" ]; then
     export GT4PY_VERSION=`cat ${pace_dir}/GT4PY_VERSION.txt`
 fi
-(cd ${pace_dir}/external/daint_venv && ./install.sh ${virtualenv_path})
+${pace_dir}/external/daint_venv/install.sh ${virtualenv_path}
 source ${virtualenv_path}/bin/activate
 python3 -m pip install ${pace_dir}/pace-util/
 python3 -m pip install $wheel_command -c ${pace_dir}/constraints.txt -r fv3core/requirements/requirements_daint.txt

--- a/fv3core/.jenkins/install_virtualenv.sh
+++ b/fv3core/.jenkins/install_virtualenv.sh
@@ -19,7 +19,7 @@ fv3core_dir=`dirname $0`/../
 if [ -z "${GT4PY_VERSION}" ]; then
     export GT4PY_VERSION=`cat ${fv3core_dir}/GT4PY_VERSION.txt`
 fi
-(cd ${fv3core_dir}/external/daint_venv && ./install.sh ${virtualenv_path})
+${fv3core_dir}/external/daint_venv/install.sh ${virtualenv_path}
 source ${virtualenv_path}/bin/activate
 python3 -m pip install ${fv3core_dir}/external/pace-util/
 python3 -m pip install $wheel_command -c ${fv3core_dir}/constraints.txt -r ${fv3core_dir}/requirements/requirements_daint.txt


### PR DESCRIPTION
We currently only support absolute path for installing virtualenv. In this PR, we allow both absolute and relative path as an input to install_virtualenv. 