### PR TITLE
ensure that artifacts are stored if in the main branch

### DIFF
--- a/fv3core/.jenkins/actions/run_standalone.sh
+++ b/fv3core/.jenkins/actions/run_standalone.sh
@@ -43,7 +43,7 @@ if [ "${SAVE_CACHE}" != "true" -a "${DO_PROFILE}" != "true" ] ; then
     SAVE_TIMINGS="true"
 fi
 # check if we store the results of this run
-if [[ "$GIT_BRANCH" != "origin/master" ]]; then
+if [[ "$GIT_BRANCH" != "origin/main" ]]; then
     SAVE_ARTIFACTS="false"
 fi
 


### PR DESCRIPTION
We only saved artifacts from `origin/master` - this led to no performance data saved after switching to pace