### PR TITLE
Add timesteps arg to run_standalone.sh

### DIFF
--- a/fv3core/.jenkins/actions/run_standalone.sh
+++ b/fv3core/.jenkins/actions/run_standalone.sh
@@ -52,7 +52,14 @@ SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
 DATA_VERSION=`grep 'FORTRAN_SERIALIZED_DATA_VERSION *=' ${ROOT_DIR}/Makefile | cut -d '=' -f 2`
-TIMESTEPS=60
+if [ "$2" != "" ]; then
+    TIMESTEPS=$2
+elif [ "${SAVE_CACHE}" == "true" ]; then
+    TIMESTEPS=2
+else
+    TIMESTEPS=60
+fi
+
 # Could parse from namelist, ranks = 6 * layout[0] * layout[1]
 RANKS=`echo ${experiment} | grep -o -E '[0-9]+ranks' | grep -o -E '[0-9]+'`
 BENCHMARK_DIR=${ROOT_DIR}/examples/standalone/benchmarks
@@ -74,9 +81,6 @@ if [ ! -d "${ARTIFACT_ROOT}" ] ; then
 fi
 if [ ! -d "${BENCHMARK_DIR}" ] ; then
     exitError 1005 ${LINENO} "Benchmark directory ${BENCHMARK_DIR} does not exist"
-fi
-if [ "${SAVE_CACHE}" == "true" ] ; then
-    TIMESTEPS=2
 fi
 
 # GTC backend name fix: passed as gtc_gt_* but their real name are gtc:gt:*


### PR DESCRIPTION
## Purpose

This PR allows us to specify the number of timesteps to execute when running run_standalone.sh, which will allow executing the profiling run in a debug mode with only 2 timesteps.

## Infrastructure changes:

- Added optional second arg to run_standalone.sh, which is the number of timesteps to execute