### PR TITLE
Remove references to s1053, use installdir instead

### DIFF
--- a/.jenkins/install_virtualenv.sh
+++ b/.jenkins/install_virtualenv.sh
@@ -11,8 +11,11 @@ exitError()
 
 # check a virtualenv path has been provided
 test -n "$1" || exitError 1001 ${virtualenv_path} "must pass an argument"
-wheel_dir=${installdir}/wheeldir
-wheel_command="--find-links=$wheel_dir"
+if [ "$WHEEL_DIR" != "" ]; then
+    wheel_command="--find-links=$WHEEL_DIR"
+else
+    wheel_command=""
+fi
 make update_submodules_venv
 virtualenv_path=$1
 pace_dir=`dirname $0`/../

--- a/.jenkins/install_virtualenv.sh
+++ b/.jenkins/install_virtualenv.sh
@@ -11,7 +11,7 @@ exitError()
 
 # check a virtualenv path has been provided
 test -n "$1" || exitError 1001 ${virtualenv_path} "must pass an argument"
-wheel_dir=/project/s1053/install/wheeldir
+wheel_dir=${installdir}/wheeldir
 wheel_command="--find-links=$wheel_dir"
 make update_submodules_venv
 virtualenv_path=$1
@@ -23,7 +23,7 @@ fi
 ${pace_dir}/external/daint_venv/install.sh ${virtualenv_path}
 source ${virtualenv_path}/bin/activate
 python3 -m pip install ${pace_dir}/pace-util/
-python3 -m pip install $wheel_command -c ${pace_dir}/constraints.txt -r fv3core/requirements/requirements_daint.txt
+python3 -m pip install $wheel_command -c ${pace_dir}/constraints.txt -r fv3core/requirements/requirements_base.txt
 python3 -m pip install ${PACE_INSTALL_FLAGS} ${pace_dir}/fv3core/
 python3 -m pip install ${PACE_INSTALL_FLAGS} ${pace_dir}/fv3gfs-physics/
 python3 -m pip install ${PACE_INSTALL_FLAGS} ${pace_dir}/stencils/

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -140,7 +140,6 @@ if [ -z ${SCRATCH} ] ; then
 fi
 
 # Set the host data head directory location
-export TEST_DATA_DIR="/project/s1053/fv3core_serialized_test_data/${DATA_VERSION}"
 export TEST_DATA_DIR="${SCRATCH}/jenkins/scratch/fv3core_fortran_data/${DATA_VERSION}"
 export FV3_STENCIL_REBUILD_FLAG=False
 # Set the host data location

--- a/external/daint_venv/install.sh
+++ b/external/daint_venv/install.sh
@@ -5,8 +5,8 @@ BUILDENV_DIR=$SCRIPT_DIR/../../buildenv
 
 VERSION=vcm_1.0
 env_file=env.daint.sh
-dst_dir=${1:-/project/s1053/install/venv/${VERSION}}
-wheeldir=${2:-/project/s1053/install/wheeldir}
+dst_dir=${1:-${installdir}/venv/${VERSION}}
+wheeldir=${2:-${installdir}/wheeldir}
 save_wheel=${3: false}
 src_dir=$(pwd)
 
@@ -55,6 +55,8 @@ if [ $save_wheel ]; then
     python3 -m pip wheel --wheel-dir=$wheeldir "gt4py/[${cuda_version}]"
 fi
 python3 -m pip install --find-links=$wheeldir "gt4py/[${cuda_version}]"
+
+python3 -m pip install ${installdir}/mpi4py/mpi4py-3.1.0a0-cp38-cp38-linux_x86_64.whl
 
 # deactivate virtual environment
 deactivate

--- a/external/daint_venv/install.sh
+++ b/external/daint_venv/install.sh
@@ -5,9 +5,6 @@ BUILDENV_DIR=$SCRIPT_DIR/../../buildenv
 
 VERSION=vcm_1.0
 env_file=env.daint.sh
-dst_dir=${1:-${installdir}/venv/${VERSION}}
-wheeldir=${2:-${installdir}/wheeldir}
-save_wheel=${3: false}
 src_dir=$(pwd)
 
 # versions
@@ -21,6 +18,10 @@ source ${BUILDENV_DIR}/${env_file}
 # echo commands and stop on error
 set -e
 set -x
+
+dst_dir=${1:-${installdir}/venv/${VERSION}}
+wheeldir=${2:-${installdir}/wheeldir}
+save_wheel=${3: false}
 
 # delete any pre-existing venv directories
 if [ -d ${dst_dir} ] ; then

--- a/fv3core/.jenkins/install_virtualenv.sh
+++ b/fv3core/.jenkins/install_virtualenv.sh
@@ -11,7 +11,7 @@ exitError()
 
 # check a virtualenv path has been provided
 test -n "$1" || exitError 1001 ${virtualenv_path} "must pass an argument"
-wheel_dir=/project/s1053/install/wheeldir
+wheel_dir=${installdir}/wheeldir
 wheel_command="--find-links=$wheel_dir"
 make update_submodules_venv
 virtualenv_path=$1

--- a/fv3core/.jenkins/install_virtualenv.sh
+++ b/fv3core/.jenkins/install_virtualenv.sh
@@ -11,8 +11,12 @@ exitError()
 
 # check a virtualenv path has been provided
 test -n "$1" || exitError 1001 ${virtualenv_path} "must pass an argument"
-wheel_dir=${installdir}/wheeldir
-wheel_command="--find-links=$wheel_dir"
+if [ "$WHEEL_DIR" != "" ]; then
+    wheel_command="--find-links=$WHEEL_DIR"
+else
+    wheel_command=""
+fi
+
 make update_submodules_venv
 virtualenv_path=$1
 fv3core_dir=`dirname $0`/../
@@ -22,7 +26,7 @@ fi
 ${fv3core_dir}/external/daint_venv/install.sh ${virtualenv_path}
 source ${virtualenv_path}/bin/activate
 python3 -m pip install ${fv3core_dir}/external/pace-util/
-python3 -m pip install $wheel_command -c ${fv3core_dir}/constraints.txt -r ${fv3core_dir}/requirements/requirements_daint.txt
+python3 -m pip install $wheel_command -c ${fv3core_dir}/constraints.txt -r ${fv3core_dir}/requirements/requirements_base.txt
 python3 -m pip install ${FV3CORE_INSTALL_FLAGS} ${fv3core_dir}
 python3 -m pip install ${fv3core_dir}/external/stencils/
 python3 -m pip install ${fv3core_dir}/external/dsl/

--- a/fv3core/.jenkins/jenkins.sh
+++ b/fv3core/.jenkins/jenkins.sh
@@ -164,7 +164,6 @@ if [ -z ${SCRATCH} ] ; then
 fi
 
 # Set the host data head directory location
-export TEST_DATA_DIR="/project/s1053/fv3core_serialized_test_data/${DATA_VERSION}"
 export TEST_DATA_DIR="${SCRATCH}/jenkins/scratch/fv3core_fortran_data/${DATA_VERSION}"
 export FV3_STENCIL_REBUILD_FLAG=False
 # Set the host data location

--- a/fv3core/requirements/requirements_daint.txt
+++ b/fv3core/requirements/requirements_daint.txt
@@ -1,2 +1,0 @@
--r requirements_base.txt
-/project/s1053/install/mpi4py/mpi4py-3.1.0a0-cp38-cp38-linux_x86_64.whl


### PR DESCRIPTION
## Purpose

This PR restores the "installdir" environment variable to machineEnvironment.sh in buildenv, and makes more consistent use of it inside our tests which make use of buildenv.

Depends on buildenv PR https://github.com/ai2cm/buildenv/pull/33, https://github.com/ai2cm/buildenv/pull/34.

## Infrastructure changes:

- virtualenv scripts use the ${installdir} environment variable instead of a hard-coded path to `/project/s1053/install` on daint
- requirements_daint.txt is removed, mpi4py is instead installed in daint_venv
- unused references to TEST_DATA_DIR inside `/project/s1053` are removed

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
