### PR TITLE
fix pace-util make release by adding dependent targets

### DIFF
--- a/pace-util/Makefile
+++ b/pace-util/Makefile
@@ -67,11 +67,35 @@ constraints.txt: requirements.txt requirements_gpu.txt setup.py
 	sed -i '/^\[toml\]/d' constraints.txt
 	sed -i '5s/.*/#    make constraints.txt/' constraints.txt
 
-clean:
-	$(MAKE) -c examples/mpi clean
+clean: clean-build clean-pyc clean-test
+	$(MAKE) -C examples/mpi clean
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+	rm -fr .pytest_cache
 
 reformat:
 	black $(PYTHON_FILES) $(PYTHON_INIT_FILES)
+
+dist: clean ## builds source and wheel package
+	python3 setup.py sdist
+	python3 setup.py bdist_wheel
+	ls -l dist
 
 release: dist ## package and upload a release
 	twine upload dist/*


### PR DESCRIPTION
## Purpose

This PR adds build and clean targets required for `make release` in pace-util.

## Infrastructure changes:

- fix pace-util `make release` by adding dependent targets

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
