### PR TITLE
stabilize fv3core performance

### DIFF
--- a/fv3core/examples/standalone/benchmarks/run_on_daint.sh
+++ b/fv3core/examples/standalone/benchmarks/run_on_daint.sh
@@ -22,8 +22,7 @@ SCRIPT_DIR=`dirname $SCRIPT`
 FV3CORE_DIR="$(dirname "$(dirname "$(dirname "$SCRIPT_DIR")")")"
 BUILDENV_DIR="$FV3CORE_DIR/../buildenv"
 NTHREADS=12
-
-export PYTHONOPTIMIZE=TRUE
+env_vars="export PYTHONOPTIMIZE=TRUE\nexport CRAY_CUDA_MPS=0"
 
 # utility functions
 function exitError()
@@ -153,7 +152,7 @@ sed -i "s/<CPUSPERTASK>/$NTHREADS/g" run.daint.slurm
 sed -i "s/<OUTFILE>/run.daint.out\n#SBATCH --hint=nomultithread/g" run.daint.slurm
 sed -i "s/00:45:00/03:15:00/g" run.daint.slurm
 sed -i "s/cscsci/normal/g" run.daint.slurm
-sed -i "s#<CMD>#srun python $py_args examples/standalone/runfile/dynamics.py $data_path $timesteps $backend $githash $run_args#g" run.daint.slurm
+sed -i "s#<CMD>#$env_vars\nsrun python $py_args examples/standalone/runfile/dynamics.py $data_path $timesteps $backend $githash $run_args#g" run.daint.slurm
 # execute on a gpu node
 set +e
 res=$(sbatch -W -C gpu run.daint.slurm 2>&1)


### PR DESCRIPTION
## Purpose
Since we've moved from fv3core to pace, the performance has been unstable, ranging between the expected 3.5 seconds to 7 seconds for c128_6ranks_baroclinic timesteps with the gtc:gt:gpu backend.  We've identified that the change in default CUDA flags set in buildenv, specifically always having CRAY_CUDA_MPS=1 as the likely source of this fluctuation through experimentation with and without the flag. This flag supports multiple ranks using the same gpu, which we do make use of for 54 rank parallel tests (so our CI doesn't have to run 54 nodes on PR). But specifically for run_on_daint, even though we are specifying that each ranks works on 1 gpu only through other slurm settings, appears to result in inconsistent performance of the halo updates. Performance analysis using CUDA_LAUNCH_BLOCKING showed that the fluctuations were happening primarily during halo updates, but the halo update code hadn't changed functionally (though has quite a bit cosmetically) since performance was stable in fv3core. 

## Code changes:

- The performance job script run_on_daint submits specifies that CRAY_CUDA_MPS=0. 
- The PYTHONOPTIMIZE setting was also moved to the slurm script rather than a setting in run_on_daint, to make relaunching the batch script easy to do without rerunning run_standalone or run_on_daint. 

