### PR TITLE
Pace util mostly does not depend on dsl

### DIFF
--- a/driver/tests/test_driver.py
+++ b/driver/tests/test_driver.py
@@ -119,7 +119,7 @@ def test_driver_dycore_only():
 
 
 def test_driver_runs():
-    driver, args = setup_driver(dycore_only=True)
+    driver, args = setup_driver(dycore_only=False)
     with no_lagrangian_contributions(dynamical_core=driver.dycore):
         driver.step(*args)
 

--- a/fv3gfs-physics/tests/savepoint/translate/translate_fv_update_phys.py
+++ b/fv3gfs-physics/tests/savepoint/translate/translate_fv_update_phys.py
@@ -357,10 +357,8 @@ class TranslateFVUpdatePhys(ParallelTranslate2Py):
             origin=self.grid.sizer.get_origin(dims_v),
             extent=self.grid.sizer.get_extent(dims_v),
         )
-        state.u_quantity = u_quantity
-        state.u = u_quantity.storage
-        state.v_quantity = v_quantity
-        state.v = v_quantity.storage
+        state.u = u_quantity
+        state.v = v_quantity
         self._base.compute_func(
             state,
             tendencies["u_dt"],
@@ -376,12 +374,10 @@ class TranslateFVUpdatePhys(ParallelTranslate2Py):
         out["qsnow"] = state.qsnow[self.grid.slice_dict(ds)]
         out["qgraupel"] = state.qgraupel[self.grid.slice_dict(ds)]
         out["pt"] = state.pt[self.grid.slice_dict(ds)]
-        state.u.synchronize()
-        state.v.synchronize()
         state.ua.synchronize()
         state.va.synchronize()
-        out["u"] = np.asarray(state.u)[self.grid.y3d_domain_interface()]
-        out["v"] = np.asarray(state.v)[self.grid.x3d_domain_interface()]
+        out["u"] = np.asarray(state.u.data)[self.grid.y3d_domain_interface()]
+        out["v"] = np.asarray(state.v.data)[self.grid.x3d_domain_interface()]
         out["ua"] = np.asarray(state.ua)[self.grid.slice_dict(ds)]
         out["va"] = np.asarray(state.va)[self.grid.slice_dict(ds)]
         return out

--- a/pace-util/pace/util/grid/helper.py
+++ b/pace-util/pace/util/grid/helper.py
@@ -1,9 +1,6 @@
 import dataclasses
 from typing import Any, Optional
 
-import numpy as np
-
-from pace.dsl import gt4py_utils as utils
 from pace.dsl.typing import FloatFieldI, FloatFieldIJ
 
 from .generation import MetricTerms
@@ -515,37 +512,10 @@ class DriverGridData:
 
     @classmethod
     def new_from_metric_terms(cls, metric_terms: MetricTerms) -> "DriverGridData":
-        # TODO fix <Quantity>.storage mask for FieldI
-        shape = metric_terms.lon.data.shape
-        backend = metric_terms.edge_vect_n.gt4py_backend
-        edge_vect_n = utils.make_storage_data(
-            metric_terms.edge_vect_n.data,
-            (shape[0],),
-            axis=0,
-            backend=backend,
-        )
-        edge_vect_s = utils.make_storage_data(
-            metric_terms.edge_vect_s.data,
-            (shape[0],),
-            axis=0,
-            backend=backend,
-        )
-        east_edge_data = metric_terms.edge_vect_e.data[np.newaxis, ...]
-        east_edge_data = np.repeat(east_edge_data, shape[0], axis=0)
-        edge_vect_e = utils.make_storage_data(
-            data=east_edge_data,
-            shape=east_edge_data.shape,
-            origin=(0, 0),
-            backend=backend,
-        )
-        west_edge_data = metric_terms.edge_vect_w.data[np.newaxis, ...]
-        west_edge_data = np.repeat(west_edge_data, shape[0], axis=0)
-        edge_vect_w = utils.make_storage_data(
-            data=west_edge_data,
-            shape=west_edge_data.shape,
-            origin=(0, 0),
-            backend=backend,
-        )
+        edge_vect_n = metric_terms.edge_vect_n.storage
+        edge_vect_s = metric_terms.edge_vect_s.storage
+        edge_vect_e = metric_terms.edge_vect_e_2d.storage
+        edge_vect_w = metric_terms.edge_vect_w_2d.storage
 
         vlon1, vlon2, vlon3 = metric_terms.split_cartesian_into_storages(
             metric_terms.vlon

--- a/stencils/pace/stencils/fv_update_phys.py
+++ b/stencils/pace/stencils/fv_update_phys.py
@@ -168,8 +168,8 @@ class ApplyPhysics2Dycore:
         self._vdt_halo_updater.wait()
         self._AGrid2DGridPhysics(state.u, state.v, u_dt.storage, v_dt.storage)
         self._do_cubed_to_latlon(
-            state.u_quantity,
-            state.v_quantity,
+            state.u,
+            state.v,
             state.ua,
             state.va,
             self.comm,


### PR DESCRIPTION
## Purpose

Part I of `pace.util` does not depend on `pace.dsl`. In this PR, we remove dependencies of `make_storage` in `DriverGridData`. Additional edge vector data are added in Metric Terms so that we can directly access their storage in `DriverGridData`. We decide to allow `pace.util` to still depend on `pace.dsl.stencil.GridIndexing` (used strictly in fill corners in Metric Terms).

## Code changes:

- Provide a list of relevant code changes and the side effects they have on other code.

## Requirements changes:

- Provide a list of any changes made to requirements, e.g. changes to files requirements*.txt, constraints.txt, setup.py, pyproject.toml, pre-commit-config.yaml and a reason if not included in the Purpose section (e.g. incompatibility, updates, etc)

## Infrastructure changes:

- Added `edge_vect_e_2d` and `edge_vect_w_2d` in Metric Terms: they are the x/y repeated version of `edge_vect_e/w`
- Fixed `fv_update_phys` reference to dycore state quantity
- Changed `test_driver_runs` to also run post physics code

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)

