### PR TITLE
Dockerfile for plotting maps in pace

### DIFF
--- a/docker/postprocessing.Dockerfile
+++ b/docker/postprocessing.Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update &&\
+    apt install -y --no-install-recommends \
+    software-properties-common
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends\
+    g++ \
+    gcc \
+    gfortran \
+    libproj-dev \
+    proj-data \
+    proj-bin \
+    libgeos-dev
+
+RUN apt-get update -y && \
+    apt install -y --no-install-recommends \
+    git \
+    python3.9 \
+    python3.9-dev &&\
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 60
+
+RUN apt-get update -y &&\
+    apt install -y --no-install-recommends\
+    python3-pip
+
+RUN python -m pip --no-cache-dir install --upgrade pip && \
+    python -m pip --no-cache-dir install setuptools &&\
+    python -m pip --no-cache-dir install wheel
+
+RUN python -m pip --no-cache-dir \
+    install \
+    numpy \
+    matplotlib \
+    cython \
+    cartopy \
+    xarray \
+    zarr
+
+# default shapely causes seg fault
+RUN pip uninstall shapely -y
+RUN pip install --no-binary :all: shapely
+
+# set up for fv3viz
+RUN cd /
+RUN git clone https://github.com/ai2cm/fv3net.git
+RUN python -m pip install fv3net/external/vcm

--- a/docker/postprocessing.Dockerfile
+++ b/docker/postprocessing.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -11,20 +11,49 @@ RUN apt-get update -y && \
     g++ \
     gcc \
     gfortran \
-    libproj-dev \
-    proj-data \
-    proj-bin \
-    libgeos-dev
+    make \
+    wget \
+    pkg-config \
+    libsqlite3-dev \
+    sqlite3 \
+    libcurl4-openssl-dev \
+    libtiff5 \
+    libtiff5-dev \
+    openssl \
+    libssl-dev
+
+RUN cd / && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
+    tar xzf cmake-3.22.2.tar.gz && \
+    rm cmake-3.22.2.tar.gz && \
+    cd cmake-3.22.2 && \
+    ./bootstrap && make -j4 && make install
+
+RUN cd / && \
+    wget http://download.osgeo.org/geos/geos-3.8.2.tar.bz2 && \
+    tar xfj geos-3.8.2.tar.bz2 && \
+    rm geos-3.8.2.tar.bz2 && \
+    cd geos-3.8.2 && \
+    mkdir _build && \
+    cd _build && \
+    cmake .. && make -j4 && ctest && make install
+
+RUN cd / && \
+    wget http://archive.ubuntu.com/ubuntu/pool/universe/p/proj/proj_8.2.1.orig.tar.gz && \
+    tar xzf proj_8.2.1.orig.tar.gz && \
+    rm proj_8.2.1.orig.tar.gz && \
+    cd proj-8.2.1 && \
+    ./configure && make -j4 && make install
 
 RUN apt-get update -y && \
     apt install -y --no-install-recommends \
     git \
-    python3.9 \
-    python3.9-dev &&\
+    python3.8 \
+    python3.8-dev &&\
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 60
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 60
 
 RUN apt-get update -y &&\
     apt install -y --no-install-recommends\
@@ -43,11 +72,8 @@ RUN python -m pip --no-cache-dir \
     xarray \
     zarr
 
-# default shapely causes seg fault
-RUN pip uninstall shapely -y
-RUN pip install --no-binary :all: shapely
-
 # set up for fv3viz
 RUN cd /
 RUN git clone https://github.com/ai2cm/fv3net.git
+RUN cd fv3net && git checkout 9df1bde7
 RUN python -m pip install fv3net/external/vcm


### PR DESCRIPTION
## Purpose

In order to utilize `fv3viz` on daint for plotting cubed-sphere tile data as maps with cartopy, we use a docker image to install all the requirements. Daint can run this through sarus. 

## Infrastructure changes:

- postprocessing.Dockerfile: this is the dockerfile used to make this [image](https://hub.docker.com/layers/191372666/elynnwu/pace/ubuntu18/images/sha256-386d98b40f7a86eaf85407172400a02e70e65ab4aa5af61e3c739e40fd98b333?context=repo)

Instead of installing `fv3viz` as a package, we install all the requirements and import the plotting function directly. To import cube plotting inside the container:

```
import sys
sys.path.append("/fv3net/external/fv3viz/")
from fv3viz import pcolormesh_cube
```

To plot on daint: 
```
sarus pull elynnwu/pace:ubuntu18
srun -C gpu --partition=debug --account=# sarus run --mount=type=bind,source=/path/to/data/files,destination=/work elynnwu/pace:ubuntu18 python /work/example.py
```

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)

