### PR TITLE
Adding In/Out to Remapping

### DIFF
--- a/fv3core/fv3core/stencils/fillz.py
+++ b/fv3core/fv3core/stencils/fillz.py
@@ -18,6 +18,16 @@ def fix_tracer(
     sum0: FloatFieldIJ,
     sum1: FloatFieldIJ,
 ):
+    """
+    Args:
+        q (inout):
+        dp (in):
+        dm (out):
+        dm_pos (out):
+        zfix (out):
+        sum0 (out):
+        sum1 (out):
+    """
     # reset fields
     with computation(FORWARD), interval(...):
         zfix = 0
@@ -141,6 +151,11 @@ class FillNegativeTracerValues:
         dp2: FloatField,
         tracers: Dict[str, Any],
     ):
+        """
+        Args:
+            dp2 (in): Difference in remapped pressure levels
+            tracers (inout): tracers to be filled
+        """
         tracer_list = [tracers[name] for name in utils.tracer_variables[0 : self._nq]]
         for tracer in tracer_list:
             self._fix_tracer_stencil(

--- a/fv3core/fv3core/stencils/fillz.py
+++ b/fv3core/fv3core/stencils/fillz.py
@@ -28,6 +28,7 @@ def fix_tracer(
         sum0 (out):
         sum1 (out):
     """
+    # TODO: can we make everything except q and dp temporaries?
     # reset fields
     with computation(FORWARD), interval(...):
         zfix = 0
@@ -153,8 +154,8 @@ class FillNegativeTracerValues:
     ):
         """
         Args:
-            dp2 (in): Difference in remapped pressure levels
-            tracers (inout): tracers to be filled
+            dp2 (in): pressure thickness of atmospheric layer
+            tracers (inout): tracers to fix negative masses in
         """
         tracer_list = [tracers[name] for name in utils.tracer_variables[0 : self._nq]]
         for tracer in tracer_list:

--- a/fv3core/fv3core/stencils/map_single.py
+++ b/fv3core/fv3core/stencils/map_single.py
@@ -27,7 +27,18 @@ def lagrangian_contributions(
     dp1: FloatField,
     lev: IntFieldIJ,
 ):
-
+    """
+    Args:
+        q (out):
+        pe1 (in):
+        pe2 (in):
+        q4_1 (in):
+        q4_2 (in):
+        q4_3 (in):
+        q4_4 (in):
+        dp1 (in):
+        lev (inout):
+    """
     with computation(FORWARD), interval(...):
         pl = (pe2 - pe1[0, 0, lev]) / dp1[0, 0, lev]
         if pe2[0, 0, 1] <= pe1[0, 0, lev + 1]:
@@ -112,20 +123,22 @@ class MapSingle:
         origin = (i1, j1, 0)
         domain = (*self._extents, grid_indexing.domain[2])
 
-        self._lagrangian_contributions = stencil_factory.from_origin_domain(
-            lagrangian_contributions,
-            origin=origin,
-            domain=domain,
-        )
-        self._remap_profile = RemapProfile(stencil_factory, kord, mode, i1, i2, j1, j2)
-
-        self._set_dp = stencil_factory.from_origin_domain(
-            set_dp, origin=origin, domain=domain
-        )
         self._copy_stencil = stencil_factory.from_origin_domain(
             copy_defn,
             origin=(0, 0, 0),
             domain=grid_indexing.domain_full(),
+        )
+
+        self._set_dp = stencil_factory.from_origin_domain(
+            set_dp, origin=origin, domain=domain
+        )
+
+        self._remap_profile = RemapProfile(stencil_factory, kord, mode, i1, i2, j1, j2)
+
+        self._lagrangian_contributions = stencil_factory.from_origin_domain(
+            lagrangian_contributions,
+            origin=origin,
+            domain=domain,
         )
 
     @property
@@ -152,8 +165,7 @@ class MapSingle:
             pe1 (in): Lagrangian pressure levels
             pe2 (in): Eulerian pressure levels
             qs (in): Bottom boundary condition
-            jfirst: Starting index of the J-dir compute domain
-            jlast: Final index of the J-dir compute domain
+            qmin (in): Minimum allowed value of the remapped field
         """
         if qs is None:
             qs = self._tmp_qs

--- a/fv3core/fv3core/stencils/map_single.py
+++ b/fv3core/fv3core/stencils/map_single.py
@@ -39,6 +39,7 @@ def lagrangian_contributions(
         dp1 (in):
         lev (inout):
     """
+    # TODO: Can we make lev a 2D temporary?
     with computation(FORWARD), interval(...):
         pl = (pe2 - pe1[0, 0, lev]) / dp1[0, 0, lev]
         if pe2[0, 0, 1] <= pe1[0, 0, lev + 1]:

--- a/fv3core/fv3core/stencils/map_single.py
+++ b/fv3core/fv3core/stencils/map_single.py
@@ -27,6 +27,7 @@ def lagrangian_contributions(
     dp1: FloatField,
     lev: IntFieldIJ,
 ):
+
     with computation(FORWARD), interval(...):
         pl = (pe2 - pe1[0, 0, lev]) / dp1[0, 0, lev]
         if pe2[0, 0, 1] <= pe1[0, 0, lev + 1]:

--- a/fv3core/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/fv3core/stencils/mapn_tracer.py
@@ -73,7 +73,7 @@ class MapNTracer:
             pe2 (out): Eulerian pressure levels
             dp2 (in): Difference in pressure between Eulerian levels
             tracers (inout): Dict mapping tracer names to their correstponding storages
-            qmin (in): Minimum allowed value of the remapped field
+            qmin (in): Minimum allowed value of the remapped fields
         """
         for i, q in enumerate(utils.tracer_variables[0 : self._nq]):
             self._list_of_remap_objects[i](tracers[q], pe1, pe2, self._qs, qmin=q_min)

--- a/fv3core/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/fv3core/stencils/mapn_tracer.py
@@ -72,9 +72,8 @@ class MapNTracer:
             pe1 (in): Lagrangian pressure levels
             pe2 (out): Eulerian pressure levels
             dp2 (in): Difference in pressure between Eulerian levels
-            qs (out): Field to be remapped on deformed grid
-            jfirst: Starting index of the J-dir compute domain
-            jlast: Final index of the J-dir compute domain
+            tracers (inout): Dict mapping tracer names to their correstponding storages
+            qmin (in): Minimum allowed value of the remapped field
         """
         for i, q in enumerate(utils.tracer_variables[0 : self._nq]):
             self._list_of_remap_objects[i](tracers[q], pe1, pe2, self._qs)

--- a/fv3core/fv3core/stencils/moist_cv.py
+++ b/fv3core/fv3core/stencils/moist_cv.py
@@ -158,7 +158,7 @@ def moist_pt_last_step(
         qice (in):
         qgraupel (in):
         gz (out):
-        pt (out):
+        pt (inout):
         pkz (in):
         dtmp (in):
         r_vir (in):
@@ -217,6 +217,7 @@ def moist_pkz(
         delz (in):
         r_vir (in):
     """
+    # TODO: What is happening with q_con and gz here?
     with computation(PARALLEL), interval(...):
         cvm, gz = moist_cv_nwat6_fn(
             qvapor, qliquid, qrain, qsnow, qice, qgraupel

--- a/fv3core/fv3core/stencils/moist_cv.py
+++ b/fv3core/fv3core/stencils/moist_cv.py
@@ -149,6 +149,20 @@ def moist_pt_last_step(
     dtmp: float,
     r_vir: float,
 ):
+    """
+    Args:
+        qvapor (in):
+        qliquid (in):
+        qrain (in):
+        qsnow (in):
+        qice (in):
+        qgraupel (in):
+        gz (out):
+        pt (out):
+        pkz (in):
+        dtmp (in):
+        r_vir (in):
+    """
     with computation(PARALLEL), interval(...):
         # if nwat == 2:
         #    gz = qliquid if qliquid > 0. else 0.
@@ -185,6 +199,24 @@ def moist_pkz(
     delz: FloatField,
     r_vir: float,
 ):
+    """
+    Args:
+        qvapor (in):
+        qliquid (in):
+        qrain (in):
+        qsnow (in):
+        qice (in):
+        qgraupel (in):
+        q_con (out):
+        gz (out):
+        cvm (out):
+        pkz (out):
+        pt (in):
+        cappa (out):
+        delp (in):
+        delz (in):
+        r_vir (in):
+    """
     with computation(PARALLEL), interval(...):
         cvm, gz = moist_cv_nwat6_fn(
             qvapor, qliquid, qrain, qsnow, qice, qgraupel

--- a/fv3core/fv3core/stencils/remap_profile.py
+++ b/fv3core/fv3core/stencils/remap_profile.py
@@ -120,7 +120,7 @@ def remap_constraint(
         a4_2 (inout): Second cubic interpolation coefficient
         a4_3 (inout): Third cubic interpolation coefficient
         a4_4 (inout): Fourth cubic interpolation coefficient
-        extm (in): Whether to set a4_2, a4_3, and a4_4 simply
+        extm (in): If true sets a4_2 and a4_3 as a4_1 and a4_4 to 0
     """
     da1 = a4_3 - a4_2
     da2 = da1 * da1

--- a/fv3core/fv3core/stencils/remap_profile.py
+++ b/fv3core/fv3core/stencils/remap_profile.py
@@ -47,6 +47,13 @@ def posdef_constraint_iv0(
     a4_3: FloatField,
     a4_4: FloatField,
 ):
+    """
+    Args:
+        a4_1 (inout): First cubic interpolation coefficient
+        a4_2 (inout): Second cubic interpolation coefficient
+        a4_3 (inout): Third cubic interpolation coefficient
+        a4_4 (inout): Fourth cubic interpolation coefficient
+    """
     if a4_1 <= 0.0:
         a4_2 = a4_1
         a4_3 = a4_1
@@ -76,6 +83,13 @@ def posdef_constraint_iv1(
     a4_3: FloatField,
     a4_4: FloatField,
 ):
+    """
+    Args:
+        a4_1 (inout): First cubic interpolation coefficient
+        a4_2 (inout): Second cubic interpolation coefficient
+        a4_3 (inout): Third cubic interpolation coefficient
+        a4_4 (inout): Fourth cubic interpolation coefficient
+    """
     da1 = a4_3 - a4_2
     da2 = da1 * da1
     a6da = a4_4 * da1
@@ -100,6 +114,14 @@ def remap_constraint(
     a4_4: FloatField,
     extm: BoolField,
 ):
+    """
+    Args:
+        a4_1 (inout): First cubic interpolation coefficient
+        a4_2 (inout): Second cubic interpolation coefficient
+        a4_3 (inout): Third cubic interpolation coefficient
+        a4_4 (inout): Fourth cubic interpolation coefficient
+        extm (in): Whether to set a4_2, a4_3, and a4_4 simply
+    """
     da1 = a4_3 - a4_2
     da2 = da1 * da1
     a6da = a4_4 * da1
@@ -127,6 +149,18 @@ def set_initial_vals(
     q_bot: FloatField,
     qs: FloatFieldIJ,
 ):
+    """
+    Args:
+        gam (out):
+        q (out):
+        delp (in):
+        a4_1 (in):
+        a4_2 (out):
+        a4_3 (out):
+        a4_4 (out):
+        q_bot (out):
+        qs (in):
+    """
     from __externals__ import iv, kord
 
     with computation(FORWARD):
@@ -218,6 +252,20 @@ def apply_constraints(
     ext6: BoolField,
     extm: BoolField,
 ):
+    """
+    Args:
+        q (inout):
+        gam (out):
+        a4_1 (in):
+        a4_2 (out):
+        a4_3 (out):
+        a4_4 (out):
+        ext5 (out):
+        ext6 (out):
+        extm (out):
+    """
+    # TODO: q is not consumed in remap_profile after this stencil.
+    # Can we remove it or set it to be purely an input here?
     from __externals__ import iv, kord
 
     # apply constraints
@@ -292,6 +340,20 @@ def set_interpolation_coefficients(
     extm: BoolField,
     qmin: float,
 ):
+    """
+    Args:
+        q (in):
+        gam (in):
+        a4_1 (inout):
+        a4_2 (inout):
+        a4_3 (inout):
+        a4_4 (inout):
+        ext5 (in):
+        ext6 (in):
+        extm (in):
+        qmin (in):
+    """
+    # TODO: q isn't used here. We should take it out of the call signature
     from __externals__ import iv, kord
 
     # set_top_as_iv0
@@ -584,13 +646,13 @@ class RemapProfile:
         distribution of the remapped field within each deformed grid cell.
         The constraints on the spline are set by kord and iv.
         Arguments:
-            qs: Bottom boundary condition
-            a4_1: The first interpolation coefficient
-            a4_2: The second interpolation coefficient
-            a4_3: The third interpolation coefficient
-            a4_4: The fourth interpolation coefficient
-            delp: The pressure difference between grid levels
-            qmin: The minimum value the field can take in a cell
+            qs (in): Bottom boundary condition
+            a4_1 (out): The first interpolation coefficient
+            a4_2 (out): The second interpolation coefficient
+            a4_3 (out): The third interpolation coefficient
+            a4_4 (out): The fourth interpolation coefficient
+            delp (in): The pressure difference between grid levels
+            qmin (in): The minimum value the field can take in a cell
         """
         self._set_initial_values(
             self._gam,

--- a/fv3core/fv3core/stencils/remapping.py
+++ b/fv3core/fv3core/stencils/remapping.py
@@ -60,6 +60,7 @@ def undo_delz_adjust_and_copy_peln(
         pe0 (out):
         pn2 (in):
     """
+    # TODO: We can assign pe0 and peln outside of a stencil to save the data copying
     with computation(PARALLEL), interval(0, -1):
         delz = -delz * delp
     with computation(PARALLEL), interval(...):
@@ -224,6 +225,7 @@ def pressures_mapv(
         pe0 (out):
         pe3 (out):
     """
+    # TODO: Combine pressures_mapu and pressures_mapv
     with computation(BACKWARD):
         with interval(-1, None):
             pe_bottom = pe
@@ -520,20 +522,21 @@ class LagrangianToEulerian:
         ua (inout): A-grid x-velocity
         va (inout): A-grid y-velocity
         cappa (inout): Power to raise pressure to
-        q_con (inout): Total condensate mixing ratio
-        q_cld (inout): Cloud fraction
+        q_con (out): Total condensate mixing ratio
+        q_cld (out): Cloud fraction
         pkz (in): Layer mean pressure raised to the power of Kappa
-        pk (inout): Interface pressure raised to power of kappa, final acoustic value
-        pe (inout): Pressure at layer edges
+        pk (out): Interface pressure raised to power of kappa, final acoustic value
+        pe (in): Pressure at layer edges
         hs (in): Surface geopotential
-        te0_2d (inout): Atmosphere total energy in columns
+        te0_2d (unused): Atmosphere total energy in columns
         ps (inout): Surface pressure
         wsd (in): Vertical velocity of the lowest level
-        omga (inout): Vertical pressure velocity
+        omga (unused): Vertical pressure velocity
         ak (in): Atmosphere hybrid a coordinate (Pa)
         bk (in): Atmosphere hybrid b coordinate (dimensionless)
         pfull (in): Pressure full levels
-        dp1 (inout): Pressure thickness before dyn_core
+        dp1 (out): Pressure thickness before dyn_core (only written
+            if do_sat_adjust=True)
         ptop (in): The pressure level at the top of atmosphere
         akap (in): Poisson constant (KAPPA)
         zvir (in): Constant (Rv/Rd-1)
@@ -547,6 +550,7 @@ class LagrangianToEulerian:
         Remap the deformed Lagrangian surfaces onto the reference, or "Eulerian",
         coordinate levels.
         """
+        # TODO: remove unused arguments (and commented code that references them)
         self._init_pe(pe, self._pe1, self._pe2, ptop)
 
         self._moist_cv_pt_pressure(

--- a/fv3core/fv3core/stencils/remapping.py
+++ b/fv3core/fv3core/stencils/remapping.py
@@ -529,7 +529,7 @@ class LagrangianToEulerian:
         pe (in): Pressure at layer edges
         hs (in): Surface geopotential
         te0_2d (unused): Atmosphere total energy in columns
-        ps (inout): Surface pressure
+        ps (out): Surface pressure
         wsd (in): Vertical velocity of the lowest level
         omga (unused): Vertical pressure velocity
         ak (in): Atmosphere hybrid a coordinate (Pa)
@@ -551,6 +551,7 @@ class LagrangianToEulerian:
         coordinate levels.
         """
         # TODO: remove unused arguments (and commented code that references them)
+        # TODO: can we trim ps or make it a temporary
         self._init_pe(pe, self._pe1, self._pe2, ptop)
 
         self._moist_cv_pt_pressure(

--- a/fv3core/fv3core/stencils/remapping.py
+++ b/fv3core/fv3core/stencils/remapping.py
@@ -29,6 +29,13 @@ CONSV_MIN = 0.001
 
 
 def init_pe(pe: FloatField, pe1: FloatField, pe2: FloatField, ptop: float):
+    """
+    Args:
+        pe (in):
+        pe1 (out):
+        pe2 (out):
+        ptop (in):
+    """
     with computation(PARALLEL):
         with interval(0, 1):
             pe2 = ptop
@@ -45,6 +52,14 @@ def undo_delz_adjust_and_copy_peln(
     pe0: FloatField,
     pn2: FloatField,
 ):
+    """
+    Args:
+        delp (in):
+        delz (inout):
+        peln (inout):
+        pe0 (out):
+        pn2 (in):
+    """
     with computation(PARALLEL), interval(0, -1):
         delz = -delz * delp
     with computation(PARALLEL), interval(...):
@@ -76,6 +91,30 @@ def moist_cv_pt_pressure(
     peln: FloatField,
     r_vir: float,
 ):
+    """
+    Args:
+        qvapor (in):
+        qliquid (in):
+        qrain (in):
+        qsnow (in):
+        qice (in):
+        qgraupel (in):
+        q_con (out):
+        gz (out):
+        cvm (out):
+        pt (inout):
+        cappa (out):
+        delp (inout):
+        delz (inout):
+        pe (in):
+        pe2 (inout):
+        ak (in):
+        bk (in):
+        dp2 (out):
+        ps (out):
+        pn2 (out):
+        peln (in):
+    """
     from __externals__ import hydrostatic, kord_tm
 
     # moist_cv.moist_pt
@@ -126,6 +165,14 @@ def pn2_pk_delp(
     pk: FloatField,
     akap: float,
 ):
+    """
+    Args:
+        dp2 (in):
+        delp (out):
+        pe2 (in):
+        pn2 (out):
+        pk (out):
+    """
     with computation(PARALLEL), interval(...):
         delp = dp2
         pn2 = log(pe2)
@@ -140,6 +187,15 @@ def pressures_mapu(
     pe0: FloatField,
     pe3: FloatField,
 ):
+    """
+    Args:
+        pe (in):
+        pe1 (in):
+        ak (in):
+        bk (in):
+        pe0 (out):
+        pe3 (out):
+    """
     with computation(BACKWARD):
         with interval(-1, None):
             pe_bottom = pe
@@ -160,6 +216,14 @@ def pressures_mapu(
 def pressures_mapv(
     pe: FloatField, ak: FloatFieldK, bk: FloatFieldK, pe0: FloatField, pe3: FloatField
 ):
+    """
+    Args:
+        pe (in):
+        ak (in):
+        bk (in):
+        pe0 (out):
+        pe3 (out):
+    """
     with computation(BACKWARD):
         with interval(-1, None):
             pe_bottom = pe
@@ -176,6 +240,11 @@ def pressures_mapv(
 
 
 def update_ua(pe2: FloatField, ua: FloatField):
+    """
+    Args:
+        pe2 (in):
+        ua (out):
+    """
     from __externals__ import local_je
 
     with computation(PARALLEL), interval(...):
@@ -190,6 +259,11 @@ def update_ua(pe2: FloatField, ua: FloatField):
 
 
 def copy_from_below(a: FloatField, b: FloatField):
+    """
+    Args:
+        a (in):
+        b (out):
+    """
     with computation(PARALLEL), interval(1, None):
         b = a[0, 0, -1]
 

--- a/fv3core/fv3core/stencils/saturation_adjustment.py
+++ b/fv3core/fv3core/stencils/saturation_adjustment.py
@@ -533,6 +533,15 @@ def compute_q_tables(
     desw: FloatField,
     des2: FloatField,
 ):
+    """
+    Args:
+        index (in):
+        tablew (out):
+        table2 (out):
+        table (out):
+        desw (out):
+        des2 (out):
+    """
     with computation(PARALLEL), interval(...):
         tablew = qs_tablew_fn(index)
         table2 = qs_table2_fn(index)
@@ -577,6 +586,43 @@ def satadjust(
     fac_l2v: float,
     last_step: bool,
 ):
+    """
+    Args:
+        peln (in):
+        qv (inout):
+        ql (inout):
+        qi (inout):
+        qr (inout):
+        qs (inout):
+        cappa (out):
+        qg (inout):
+        pt (inout):
+        dp (in):
+        delz (inout): If nonhydrostatic delz is only in, not out
+        te0 (out):
+        q_con (out):
+        qa (out):
+        area (in):
+        hs (in):
+        pkz (out):
+        sdt (in):
+        zvir (in):
+        fac_i2s (in):
+        do_qa (in):
+        consv_te (in):
+        c_air (in):
+        c_vap (in):
+        mdt (in):
+        fac_r2g (in):
+        fac_smlt (in):
+        fac_l2r (in):
+        fac_imlt (in):
+        d0_vap (in):
+        lv00 (in):
+        fac_v2l (in):
+        fac_l2v (in):
+        last_step (in):
+    """
     from __externals__ import (
         cld_min,
         dw_land,
@@ -946,6 +992,32 @@ class SatAdjust3d:
         akap: float,
         kmp: int,
     ):
+        """
+        Args:
+            te (out):
+            qvapor (inout):
+            qliquid (inout):
+            qice (inout):
+            qrain (inout):
+            qsnow (inout):
+            qgraupel (inout):
+            qcld (out):
+            hs (in):
+            peln (in):
+            delp (in):
+            delz (inout): If nonhydrostatic delz is only in, not out
+            q_con (out):
+            pt (inout):
+            pkz (out):
+            cappa (out):
+            r_vir (in):
+            mdt (in):
+            fast_mp_consv (in):
+            last_step (in):
+            akap (in):
+            kmp (in):
+        """
+        # TODO: akap and kmp are not used and should be removed from the call
         sdt = 0.5 * mdt  # half remapping time step
         # define conversion scalar / factor
         fac_i2s = 1.0 - math.exp(-mdt / self._config.tau_i2s)

--- a/fv3core/fv3core/stencils/saturation_adjustment.py
+++ b/fv3core/fv3core/stencils/saturation_adjustment.py
@@ -1003,7 +1003,7 @@ class SatAdjust3d:
             qgraupel (inout):
             qcld (out):
             hs (in):
-            peln (in):
+            peln (in): only read if hydrostartc, otherwise unused
             delp (in):
             delz (inout): If nonhydrostatic delz is only in, not out
             q_con (out):
@@ -1014,10 +1014,11 @@ class SatAdjust3d:
             mdt (in):
             fast_mp_consv (in):
             last_step (in):
-            akap (in):
-            kmp (in):
+            akap (unused):
+            kmp (unused):
         """
         # TODO: akap and kmp are not used and should be removed from the call
+        # TODO: Maybe remove hydrostatic code
         sdt = 0.5 * mdt  # half remapping time step
         # define conversion scalar / factor
         fac_i2s = 1.0 - math.exp(-mdt / self._config.tau_i2s)


### PR DESCRIPTION
## Purpose

This PR adds docstrings with in/out/inout for stencils and classes used in vertical remapping, and reorders the definition and initialization of stencils to match the call order.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
