### PR TITLE
convert u_contra_dxc and v_contra_dyc to temporaries, remove ptc input form D_SW

### DIFF
--- a/fv3core/fv3core/stencils/d_sw.py
+++ b/fv3core/fv3core/stencils/d_sw.py
@@ -966,7 +966,6 @@ class DGridShallowWaterLagrangianDynamics:
         self,
         delpc,
         delp,
-        ptc,
         pt,
         u,
         v,
@@ -1000,7 +999,6 @@ class DGridShallowWaterLagrangianDynamics:
         Args:
             delpc (inout): C-grid  vertical delta in pressure
             delp (inout): D-grid vertical delta in pressure
-            ptc : C-grid potential temperature
             pt (inout): D-grid potential teperature
             u (inout): D-grid x-velocity
             v (inout): D-grid y-velocity
@@ -1186,7 +1184,6 @@ class DGridShallowWaterLagrangianDynamics:
             u,
             v,
             va,
-            ptc,
             self._tmp_vort,
             ua,
             divgd,

--- a/fv3core/fv3core/stencils/divergence_damping.py
+++ b/fv3core/fv3core/stencils/divergence_damping.py
@@ -402,15 +402,15 @@ class DivergenceDamping:
             u (in):
             v (in):
             va (in):
-            v_contra_dxc (out):
+            v_contra_dxc (out): wk converted from a grid to b grid and damped
             ua (in):
             divg_d (inout):
             vc (inout):
             uc (inout):
             delpc (out):
             ke (inout): gets vort added to it
-            wk (in): gets converted by a2b_ord4 and put into vort at end (in)
-            dt: timestep (in)
+            wk (in): gets converted by a2b_ord4 and put into v_contra_dxc
+            dt (in): timestep
         """
         # in the original Fortran, u_contra_dyc is "ptc" and v_contra_dxc is "vort"
         if self._do_zero_order:

--- a/fv3core/fv3core/stencils/divergence_damping.py
+++ b/fv3core/fv3core/stencils/divergence_damping.py
@@ -45,8 +45,6 @@ def get_delpc(
     sina_v: FloatFieldIJ,
     rarea_c: FloatFieldIJ,
     delpc: FloatField,
-    u_contra_dyc: FloatField,
-    v_contra_dxc: FloatField,
 ):
     """
     Args:
@@ -68,8 +66,6 @@ def get_delpc(
         sina_v (in):
         rarea_c (in):
         delpc (out):
-        u_contra_dyc (out):
-        v_contra_dxc (out):
     """
     from __externals__ import i_end, i_start, j_end, j_start
 
@@ -391,7 +387,6 @@ class DivergenceDamping:
         u: FloatField,
         v: FloatField,
         va: FloatField,
-        u_contra_dyc: FloatField,
         v_contra_dxc: FloatField,
         ua: FloatField,
         divg_d: FloatField,
@@ -407,7 +402,6 @@ class DivergenceDamping:
             u (in):
             v (in):
             va (in):
-            u_contra_dyc (out):
             v_contra_dxc (out):
             ua (in):
             divg_d (inout):
@@ -441,8 +435,6 @@ class DivergenceDamping:
                 self._sina_v,
                 self._rarea_c,
                 delpc,
-                u_contra_dyc,
-                v_contra_dxc,
             )
             self._damping(
                 delpc,

--- a/fv3core/fv3core/stencils/dyn_core.py
+++ b/fv3core/fv3core/stencils/dyn_core.py
@@ -668,7 +668,6 @@ class AcousticDynamics:
             self.dgrid_shallow_water_lagrangian_dynamics(
                 state.vt,
                 state.delp,
-                state.ptc,
                 state.pt,
                 state.u,
                 state.v,

--- a/fv3core/tests/savepoint/translate/translate_d_sw.py
+++ b/fv3core/tests/savepoint/translate/translate_d_sw.py
@@ -43,7 +43,6 @@ class TranslateD_SW(TranslateFortranData2Py):
             "diss_est": {},
             "q_con": {},
             "pt": {},
-            "ptc": {},
             "ua": {},
             "va": {},
             "zh": {},

--- a/fv3core/tests/savepoint/translate/translate_divergencedamping.py
+++ b/fv3core/tests/savepoint/translate/translate_divergencedamping.py
@@ -11,7 +11,6 @@ class TranslateDivergenceDamping(TranslateFortranData2Py):
             "u": {},
             "v": {},
             "va": {},
-            "u_contra_dyc": {"serialname": "ptc"},
             "v_contra_dxc": {"serialname": "vort"},
             "ua": {},
             "divg_d": {},


### PR DESCRIPTION
## Code changes:

- Remove ptc as an input in d_sw.py, using a temporary instead
- remove u_contra_dxc and v_contra_dyc as inputs to get_delpc, using a temporary instead

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
