### PR TITLE
Driver diagnostics write out lat/lon info

### DIFF
--- a/docker/postprocessing.Dockerfile
+++ b/docker/postprocessing.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -11,49 +11,20 @@ RUN apt-get update -y && \
     g++ \
     gcc \
     gfortran \
-    make \
-    wget \
-    pkg-config \
-    libsqlite3-dev \
-    sqlite3 \
-    libcurl4-openssl-dev \
-    libtiff5 \
-    libtiff5-dev \
-    openssl \
-    libssl-dev
-
-RUN cd / && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
-    tar xzf cmake-3.22.2.tar.gz && \
-    rm cmake-3.22.2.tar.gz && \
-    cd cmake-3.22.2 && \
-    ./bootstrap && make -j4 && make install
-
-RUN cd / && \
-    wget http://download.osgeo.org/geos/geos-3.8.2.tar.bz2 && \
-    tar xfj geos-3.8.2.tar.bz2 && \
-    rm geos-3.8.2.tar.bz2 && \
-    cd geos-3.8.2 && \
-    mkdir _build && \
-    cd _build && \
-    cmake .. && make -j4 && ctest && make install
-
-RUN cd / && \
-    wget http://archive.ubuntu.com/ubuntu/pool/universe/p/proj/proj_8.2.1.orig.tar.gz && \
-    tar xzf proj_8.2.1.orig.tar.gz && \
-    rm proj_8.2.1.orig.tar.gz && \
-    cd proj-8.2.1 && \
-    ./configure && make -j4 && make install
+    libproj-dev \
+    proj-data \
+    proj-bin \
+    libgeos-dev
 
 RUN apt-get update -y && \
     apt install -y --no-install-recommends \
     git \
-    python3.8 \
-    python3.8-dev &&\
+    python3.9 \
+    python3.9-dev &&\
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 60
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 60
 
 RUN apt-get update -y &&\
     apt install -y --no-install-recommends\
@@ -72,8 +43,13 @@ RUN python -m pip --no-cache-dir \
     xarray \
     zarr
 
+# default shapely causes seg fault
+RUN pip uninstall shapely -y
+RUN pip install --no-binary :all: shapely
+
 # set up for fv3viz
 RUN cd /
 RUN git clone https://github.com/ai2cm/fv3net.git
 RUN cd fv3net && git checkout 9df1bde7
 RUN python -m pip install fv3net/external/vcm
+ENV PYTHONPATH=/fv3net/external/fv3viz

--- a/driver/examples/README.md
+++ b/driver/examples/README.md
@@ -19,7 +19,9 @@ $ python3 zarr_to_nc.py output.zarr output.nz
 To run a baroclinic c12 case with Docker in a single command, run `run_docker.sh`.
 This example will start from the Python 3.8 docker image, install extra dependencies and Python packages, and execute the example, leaving the output in this directory.
 
-There is also a script `plot_output.py` which will show the output of the run. To use it, you must install matplotlib (e.g. with `pip install matplotlib`).
+To visualize the output, two example scripts are provided:
+1. `plot_output.py`: To use it, you must install matplotlib (e.g. with `pip install matplotlib`).
+2. `plot_cube.py`: this uses plotting tools in [fv3viz](https://github.com/ai2cm/fv3net/tree/master/external/fv3viz). Note the requirements aren't part of pace by default and need to be installed accordingly. It is recommended to use the post processing docker provided at the top level `docker/postprocessing.Dockerfile`.
 
 ## Host Machine
 

--- a/driver/examples/plot_cube.py
+++ b/driver/examples/plot_cube.py
@@ -1,0 +1,22 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+import zarr
+from cartopy import crs as ccrs
+from fv3viz import pcolormesh_cube
+
+
+ds = xr.open_zarr(store=zarr.DirectoryStore(path="output.zarr"), consolidated=False)
+fig, ax = plt.subplots(1, 1, subplot_kw={"projection": ccrs.Robinson()})
+lat = ds["lat"].values * 180.0 / np.pi
+lon = ds["lon"].values * 180.0 / np.pi
+h = pcolormesh_cube(
+    lat,
+    lon,
+    ds["ua"].isel(time=5, z=78).values,
+    cmap=plt.cm.viridis,
+    ax=ax,
+)
+fig.colorbar(h, ax=ax, location="bottom", label="u [m/s]")
+plt.tight_layout()
+plt.savefig("test.png")

--- a/driver/pace/driver/run.py
+++ b/driver/pace/driver/run.py
@@ -340,7 +340,7 @@ class Diagnostics:
             for name in ["lat", "lon"]:
                 grid_quantity = pace.util.Quantity(
                     getattr(state.grid_data, name),
-                    dims=("x_interface", "y_intercace"),
+                    dims=("x_interface", "y_interface"),
                     origin=metadata.origin,
                     extent=(metadata.extent[0] + 1, metadata.extent[1] + 1),
                     units="rad",

--- a/driver/tests/test_driver.py
+++ b/driver/tests/test_driver.py
@@ -99,7 +99,7 @@ def test_driver(timestep: timedelta, minutes: int):
     assert driver.dycore.step_dynamics.call_count == n_timesteps
     assert driver.physics.call_count == n_timesteps
     # we store an extra step at the start of the run
-    assert driver.diagnostics.store.call_count == n_timesteps + 1
+    assert driver.diagnostics.store.call_count == n_timesteps
     assert driver.dycore_to_physics.call_count == n_timesteps
     assert driver.physics_to_dycore.call_count == n_timesteps
 

--- a/pace-util/HISTORY.md
+++ b/pace-util/HISTORY.md
@@ -17,6 +17,7 @@ Minor changes:
 - added `CubedSphereCommunicator.from_layout` constructor method
 - added support for built-in `datetime` in ZarrMonitor
 - `edge_interior_ratio` is now an optional argument of `tile_extent_from_rank_metadata`
+- added support for writing grid data (constants with time) in ZarrMonitor
 
 v0.7.0
 ------

--- a/pace-util/HISTORY.md
+++ b/pace-util/HISTORY.md
@@ -17,7 +17,7 @@ Minor changes:
 - added `CubedSphereCommunicator.from_layout` constructor method
 - added support for built-in `datetime` in ZarrMonitor
 - `edge_interior_ratio` is now an optional argument of `tile_extent_from_rank_metadata`
-- added support for writing grid data (constants with time) in ZarrMonitor
+- added support for writing constant data (written once, does not change with time) in ZarrMonitor
 
 v0.7.0
 ------

--- a/pace-util/pace/util/zarr_monitor.py
+++ b/pace-util/pace/util/zarr_monitor.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import List, Tuple, Union
+from typing import Tuple, Union
 
 import cftime
 
@@ -75,7 +75,6 @@ class ZarrMonitor:
         self._group = mpi_comm.bcast(group)
         self._comm = mpi_comm
         self._writers = None
-        self._bypass_checks: List[str] = []
         self.partitioner = partitioner
 
     def _init_writers(self, state):
@@ -103,7 +102,6 @@ class ZarrMonitor:
                 "that were not present in earlier states"
             )
         missing_names = set(self._writers.keys()).difference(state.keys())
-        missing_names.difference_update(self._bypass_checks)
         if len(missing_names) != 0:
             raise ValueError(
                 f"provided state is missing keys {missing_names} "

--- a/pace-util/pace/util/zarr_monitor.py
+++ b/pace-util/pace/util/zarr_monitor.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 import cftime
 
@@ -75,6 +75,7 @@ class ZarrMonitor:
         self._group = mpi_comm.bcast(group)
         self._comm = mpi_comm
         self._writers = None
+        self._bypass_checks: List[str] = []
         self.partitioner = partitioner
 
     def _init_writers(self, state):
@@ -102,6 +103,7 @@ class ZarrMonitor:
                 "that were not present in earlier states"
             )
         missing_names = set(self._writers.keys()).difference(state.keys())
+        missing_names.difference_update(self._bypass_checks)
         if len(missing_names) != 0:
             raise ValueError(
                 f"provided state is missing keys {missing_names} "
@@ -125,6 +127,18 @@ class ZarrMonitor:
         self._ensure_writers_are_consistent(state)
         for name, quantity in sorted(state.items(), key=lambda x: x[0]):
             self._writers[name].append(quantity)  # type: ignore[index]
+
+    def store_grid(self, grid: dict) -> None:
+        for name, quantity in grid.items():
+            self._bypass_checks.append(name)
+            if self._writers is not None:
+                self._writers[name] = _ZarrGridWriter(
+                    self._comm,
+                    self._group,
+                    name=name,
+                    partitioner=self.partitioner,
+                )
+                self._writers[name].append(quantity)  # type: ignore[index]
 
 
 class _ZarrVariableWriter:
@@ -257,6 +271,51 @@ def _get_from_slice(target_slice):
         if isinstance(entry, slice):
             return_list.append(slice(0, entry.stop - entry.start))
     return tuple(return_list)
+
+
+class _ZarrGridWriter(_ZarrVariableWriter):
+    def __init__(self, *args, **kwargs):
+        super(_ZarrGridWriter, self).__init__(*args, **kwargs)
+        self._prepend_shape = (6,)
+        self._prepend_chunks = (1,)
+        self._PREPEND_DIMS = ("tile",)
+
+    def append(self, quantity):
+        # can't just use zarr_array.append because we only want to
+        # extend the dimension once, from the root rank
+        if self.array is None:
+            self._init_zarr(quantity)
+
+        self.sync_array()
+
+        target_slice = (self._partitioner.tile_index(self.rank),) + subtile_slice(
+            quantity.dims,
+            self.array.shape[1:],  # remove tile dimensions
+            self.partitioner.layout,
+            self.partitioner.tile.subtile_index(self.rank),
+            overlap=False,
+        )
+
+        from_slice = _get_from_slice(target_slice)
+        logger.debug(
+            f"assigning data from subtile slice {from_slice} to "
+            f"target slice {target_slice}"
+        )
+
+        try:
+            self.array[target_slice] = quantity.view[:][from_slice]
+        except ValueError as err:
+            if err.args[0] == "object __array__ method not producing an array":
+                self.array[target_slice] = cupy.asnumpy(quantity.view[:][from_slice])
+            else:
+                raise err
+        except TypeError as err:
+            if err.args[0].startswith(
+                "Implicit conversion to a NumPy array is not allowed."
+            ):
+                self.array[target_slice] = cupy.asnumpy(quantity.view[:][from_slice])
+            else:
+                raise err
 
 
 class _ZarrTimeWriter(_ZarrVariableWriter):

--- a/pace-util/pace/util/zarr_monitor.py
+++ b/pace-util/pace/util/zarr_monitor.py
@@ -128,17 +128,15 @@ class ZarrMonitor:
         for name, quantity in sorted(state.items(), key=lambda x: x[0]):
             self._writers[name].append(quantity)  # type: ignore[index]
 
-    def store_grid(self, grid: dict) -> None:
+    def store_constant(self, grid: dict) -> None:
         for name, quantity in grid.items():
-            self._bypass_checks.append(name)
-            if self._writers is not None:
-                self._writers[name] = _ZarrGridWriter(
-                    self._comm,
-                    self._group,
-                    name=name,
-                    partitioner=self.partitioner,
-                )
-                self._writers[name].append(quantity)  # type: ignore[index]
+            constant_writer = _ZarrConstantWriter(
+                self._comm,
+                self._group,
+                name=name,
+                partitioner=self.partitioner,
+            )
+            constant_writer.append(quantity)  # type: ignore[index]
 
 
 class _ZarrVariableWriter:
@@ -273,9 +271,9 @@ def _get_from_slice(target_slice):
     return tuple(return_list)
 
 
-class _ZarrGridWriter(_ZarrVariableWriter):
+class _ZarrConstantWriter(_ZarrVariableWriter):
     def __init__(self, *args, **kwargs):
-        super(_ZarrGridWriter, self).__init__(*args, **kwargs)
+        super(_ZarrConstantWriter, self).__init__(*args, **kwargs)
         self._prepend_shape = (6,)
         self._prepend_chunks = (1,)
         self._PREPEND_DIMS = ("tile",)


### PR DESCRIPTION
## Purpose

Driver diagnostics now writes out latitude and longitude, and we can plot cube with driver output.

## Code changes:

- `postprocessing.Dockerfile`: switch to ubuntu 22, this is now supported on daint (through sarus)
- `plot_cube.py`: an example script to plot driver output using `fv3viz`
- `driver/run.py`: add `write_grid` option to `store`, which is currently hard coded to write out only `lat` and `lon` (at the interface as part of the requirement in `fv3viz`)
- `zarr_monitor.py`: add `_ZarrGridWriter` to support writing grid data (write only once, without time coordinate)

## Requirements changes:

- [optional] `fv3viz` is used in `plot_cube.py`: this is not a requirement in pace but users have the option to follow `fv3net` requirements or use the post processing docker file

Example c48 driver output:

<img src="https://user-images.githubusercontent.com/6588606/155817433-5a68cb2b-5876-48c7-9648-e5fd8fe1f664.png" width="400">

## Infrastructure changes:

- Post processing dockerfile now uses ubuntu 22

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated


