### PR TITLE
switch to https submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/gt4py"]
 	path = external/gt4py
-	url = git@github.com:ai2cm/gt4py.git
+	url = https://github.com:ai2cm/gt4py.git
 [submodule "buildenv"]
 	path = buildenv
 	url = git@github.com:ai2cm/buildenv.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/gt4py"]
 	path = external/gt4py
-	url = https://github.com:ai2cm/gt4py.git
+	url = https://github.com/ai2cm/gt4py.git
 [submodule "buildenv"]
 	path = buildenv
 	url = git@github.com:ai2cm/buildenv.git


### PR DESCRIPTION
## Purpose

Switch gt4py submodule to https so there's no need to have github ssh configured.

## Infrastructure changes:

- `.gitsubmodules`: gt4py uses https (we do not expect to push to gt4py this way). 
    - keeping `buildenv` as it is since we do plan on pushing to that repo from pace 

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
