### PR TITLE
merge main_uc and main_vc stencils in fxadv

### DIFF
--- a/fv3core/fv3core/stencils/fxadv.py
+++ b/fv3core/fv3core/stencils/fxadv.py
@@ -1,8 +1,6 @@
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
-import pace.util
 from fv3core.stencils.d2a2c_vect import contravariant
-from fv3core.utils.functional_validation import get_set_nan_func
 from pace.dsl.stencil import StencilFactory
 from pace.dsl.typing import FloatField, FloatFieldIJ
 from pace.util.grid import GridData
@@ -543,11 +541,11 @@ class FiniteVolumeFluxPrep:
         self._fxadv_fluxes_stencil = stencil_factory.from_origin_domain(
             fxadv_fluxes_stencil, **kwargs
         )
-        self._set_nans = get_set_nan_func(
-            grid_indexing,
-            dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
-            n_halo=((2, 2), (2, 2)),
-        )
+        # self._set_nans = get_set_nan_func(
+        #     grid_indexing,
+        #     dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
+        #     n_halo=((2, 2), (2, 2)),
+        # )
 
     def __call__(
         self,
@@ -644,9 +642,8 @@ class FiniteVolumeFluxPrep:
             vc_contra,
             dt,
         )
-        if __debug__:
-            self._set_nans(uc_contra)
-            self._set_nans(vc_contra)
+        # self._set_nans(uc_contra)
+        # self._set_nans(vc_contra)
 
 
 # -------------------- DEPRECATED CORNERS-----------------

--- a/fv3core/fv3core/utils/functional_validation.py
+++ b/fv3core/fv3core/utils/functional_validation.py
@@ -1,0 +1,39 @@
+import copy
+from typing import Callable, Sequence, Tuple
+
+import numpy as np
+
+from pace.dsl.stencil import GridIndexing
+
+
+def get_subset_func(
+    grid_indexing: GridIndexing,
+    dims: Sequence[str],
+    n_halo: Tuple[Tuple[int, int], Tuple[int, int]] = ((0, 0), (0, 0)),
+) -> Callable[[np.ndarray], np.ndarray]:
+    origin, domain = grid_indexing.get_origin_domain(dims)
+    i_start = origin[0] - n_halo[0][0]
+    i_end = origin[0] + domain[0] + n_halo[0][1]
+    j_start = origin[1] - n_halo[1][0]
+    j_end = origin[1] + domain[1] + n_halo[1][1]
+
+    def subset(data):
+        return data[i_start:i_end, j_start:j_end, :]
+
+    return subset
+
+
+def get_set_nan_func(
+    grid_indexing: GridIndexing,
+    dims: Sequence[str],
+    n_halo: Tuple[Tuple[int, int], Tuple[int, int]] = ((0, 0), (0, 0)),
+) -> Callable[[np.ndarray], np.ndarray]:
+    subset = get_subset_func(grid_indexing=grid_indexing, dims=dims, n_halo=n_halo)
+
+    def set_nans(data):
+        safe = copy.deepcopy(data)
+        data[:] = np.nan
+        data_subset = subset(data)
+        data_subset[:] = subset(safe)
+
+    return set_nans

--- a/fv3core/fv3core/utils/functional_validation.py
+++ b/fv3core/fv3core/utils/functional_validation.py
@@ -33,6 +33,7 @@ def get_set_nan_func(
     def set_nans(data):
         safe = copy.deepcopy(data)
         data[:] = np.nan
+        # data_subset is a view of data, so modifying data_subset modifies data
         data_subset = subset(data)
         data_subset[:] = subset(safe)
 

--- a/fv3core/tests/savepoint/test_translate.py
+++ b/fv3core/tests/savepoint/test_translate.py
@@ -116,7 +116,7 @@ def sample_wherefail(
                 f"absolute diff {abs_err:.3e}, "
                 f"metric diff: {metric_err:.3e}"
             )
-        if metric_err > worst_metric_err:
+        if np.isnan(metric_err) or (metric_err > worst_metric_err):
             worst_metric_err = metric_err
             worst_full_idx = full_index
             worst_abs_err = abs_err


### PR DESCRIPTION
## Purpose

This PR merges two stencils in fxadv.py to improve performance.

## Code changes:

- Merged main_uc_stencil and main_vc_stencil in fxadv.py
- Remove two data copy operations
- No longer call edge/corner stencils if we aren't on an edge/corner rank in fxadv.py
- Disable validation of FxAdv on outermost halo for uc_contra and vc_contra

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated