### PR TITLE
single node compilation

### DIFF
--- a/fv3core/examples/standalone/benchmarks/run_on_daint.sh
+++ b/fv3core/examples/standalone/benchmarks/run_on_daint.sh
@@ -129,8 +129,7 @@ sed -i "s/<NTASKS>/1/g" compile.daint.slurm
 sed -i "s/<NTASKSPERNODE>/1/g" compile.daint.slurm
 sed -i "s/<CPUSPERTASK>/$NTHREADS/g" compile.daint.slurm
 sed -i "s/<OUTFILE>/compile.daint.out\n#SBATCH --hint=nomultithread/g" compile.daint.slurm
-sed -i "s/00:45:00/01:40:00/g" compile.daint.slurm
-sed -i "s/cscsci/normal/g" compile.daint.slurm
+sed -i "s/00:45:00/02:00:00/g" compile.daint.slurm
 sed -i "s#<CMD>#$env_vars\nsrun python examples/standalone/runfile/compile.py $data_path $backend #g" compile.daint.slurm
 # execute on a gpu node
 set +e
@@ -157,12 +156,6 @@ sed -i "s/<NTASKS>/$ranks/g" run.daint.slurm
 sed -i "s/<NTASKSPERNODE>/1/g" run.daint.slurm
 sed -i "s/<CPUSPERTASK>/$NTHREADS/g" run.daint.slurm
 sed -i "s/<OUTFILE>/run.daint.out\n#SBATCH --hint=nomultithread/g" run.daint.slurm
-if [ "$timesteps" -lt 5 ]
-then
-  sed -i "s/00:45:00/01:30:00/g" run.daint.slurm
-else
-  sed -i "s/00:45:00/03:15:00/g" run.daint.slurm
-fi
 sed -i "s/cscsci/normal/g" run.daint.slurm
 sed -i "s#<CMD>#$env_vars\nsrun python $py_args examples/standalone/runfile/dynamics.py $data_path $timesteps $backend $githash $run_args#g" run.daint.slurm
 # execute on a gpu node

--- a/fv3core/examples/standalone/benchmarks/run_on_daint.sh
+++ b/fv3core/examples/standalone/benchmarks/run_on_daint.sh
@@ -122,17 +122,16 @@ echo "    Extra run in nsys: $DO_NSYS_RUN"
 $FV3CORE_DIR/../.jenkins/fetch_caches.sh $backend $EXPNAME
 
 echo "submitting script to do compilation"
-env_vars="export PYTHONOPTIMIZE=TRUE\nexport CRAY_CUDA_MPS=1"
+env_vars="export PYTHONOPTIMIZE=TRUE"
 # Adapt batch script to compile the code:
 sed -i "s/<NAME>/compilestandalone/g" compile.daint.slurm
-sed -i "s/<NTASKS>/$ranks/g" compile.daint.slurm
+sed -i "s/<NTASKS>/1/g" compile.daint.slurm
 sed -i "s/<NTASKSPERNODE>/1/g" compile.daint.slurm
 sed -i "s/<CPUSPERTASK>/$NTHREADS/g" compile.daint.slurm
 sed -i "s/<OUTFILE>/compile.daint.out\n#SBATCH --hint=nomultithread/g" compile.daint.slurm
 sed -i "s/00:45:00/01:40:00/g" compile.daint.slurm
 sed -i "s/cscsci/normal/g" compile.daint.slurm
-sed -i "s/<G2G>/export CRAY_CUDA_MPS=1\nexport PYTHONOPTIMIZE=TRUE/g" compile.daint.slurm
-sed -i "s#<CMD>#$env_vars\nsrun python examples/standalone/runfile/dynamics.py $data_path 1 $backend $githash#g" compile.daint.slurm
+sed -i "s#<CMD>#$env_vars\nsrun python examples/standalone/runfile/compile.py $data_path $backend #g" compile.daint.slurm
 # execute on a gpu node
 set +e
 res=$(sbatch -W -C gpu compile.daint.slurm 2>&1)

--- a/fv3core/examples/standalone/runfile/compile.py
+++ b/fv3core/examples/standalone/runfile/compile.py
@@ -73,4 +73,4 @@ if __name__ == "__main__":
         )
         dycore, dycore_args = setup_dycore(dycore_config, mpi_comm, args.backend)
         with no_lagrangian_contributions(dynamical_core=dycore):
-            dycore.step_dynamics(*dycore_args)
+            dycore.step_dynamics(**dycore_args)

--- a/fv3core/examples/standalone/runfile/compile.py
+++ b/fv3core/examples/standalone/runfile/compile.py
@@ -5,8 +5,8 @@ from typing import Any, List, Tuple
 
 import f90nml
 
-import fv3core
 import pace.dsl.stencil
+from fv3core import DynamicalCore
 from fv3core._config import DynamicalCoreConfig
 from fv3core.initialization.baroclinic import init_baroclinic_state
 from fv3core.utils.null_comm import NullComm
@@ -14,7 +14,7 @@ from pace.util.grid import DampingCoefficients, GridData, MetricTerms
 
 
 @contextlib.contextmanager
-def no_lagrangian_contributions(dynamical_core: fv3core.DynamicalCore):
+def no_lagrangian_contributions(dynamical_core: DynamicalCore):
     # TODO: lagrangian contributions currently cause an out of bounds iteration
     # when halo updates are disabled. Fix that bug and remove this decorator.
     # Probably requires an update to gt4py (currently v36).
@@ -63,7 +63,7 @@ def parse_args() -> Namespace:
     return parser.parse_args()
 
 
-def setup_dycore(config, rank, backend) -> Tuple[fv3core.DynamicalCore, List[Any]]:
+def setup_dycore(config, rank, backend) -> Tuple[DynamicalCore, List[Any]]:
     stencil_config = pace.dsl.stencil.StencilConfig(
         backend=backend,
         rebuild=False,
@@ -112,7 +112,7 @@ def setup_dycore(config, rank, backend) -> Tuple[fv3core.DynamicalCore, List[Any
         grid_indexing=grid_indexing,
     )
 
-    dycore = fv3core.DynamicalCore(
+    dycore = DynamicalCore(
         comm=communicator,
         grid_data=GridData.new_from_metric_terms(metric_terms),
         stencil_factory=stencil_factory,

--- a/fv3core/examples/standalone/runfile/compile.py
+++ b/fv3core/examples/standalone/runfile/compile.py
@@ -83,3 +83,4 @@ if __name__ == "__main__":
         )
         with no_lagrangian_contributions(dynamical_core=dycore):
             dycore.step_dynamics(**dycore_args)
+        print("SUCCESS")

--- a/fv3core/examples/standalone/runfile/compile.py
+++ b/fv3core/examples/standalone/runfile/compile.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+import copy
+import json
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
+from typing import Any, Dict, List, Tuple
+
+import f90nml
+import numpy as np
+import serialbox
+import yaml
+from mpi4py import MPI
+
+import pace.dsl.stencil
+from fv3core._config import DynamicalCoreConfig
+from fv3core.initialization.baroclinic import init_baroclinic_state
+from fv3core.testing import TranslateFVDynamics
+from pace.util.grid import DampingCoefficients, GridData, MetricTerms
+
+
+# Dev note: the GTC toolchain fails if xarray is imported after gt4py
+# pace.util imports xarray if it's available in the env.
+# fv3core imports gt4py.
+# To avoid future conflict creeping back we make util imported prior to
+# fv3core. isort turned off to keep it that way.
+# isort: off
+import pace.util as util
+from fv3core.utils.null_comm import NullComm
+
+# isort: on
+
+import fv3core
+from pace.stencils.testing.grid import Grid
+
+@contextlib.contextmanager
+def no_lagrangian_contributions(dynamical_core: fv3core.DynamicalCore):
+    # TODO: lagrangian contributions currently cause an out of bounds iteration
+    # when halo updates are disabled. Fix that bug and remove this decorator.
+    # Probably requires an update to gt4py (currently v36).
+    def do_nothing(*args, **kwargs):
+        pass
+
+    original_attributes = {}
+    for obj in (
+        dynamical_core._lagrangian_to_eulerian_obj._map_single_delz,
+        dynamical_core._lagrangian_to_eulerian_obj._map_single_pt,
+        dynamical_core._lagrangian_to_eulerian_obj._map_single_u,
+        dynamical_core._lagrangian_to_eulerian_obj._map_single_v,
+        dynamical_core._lagrangian_to_eulerian_obj._map_single_w,
+        dynamical_core._lagrangian_to_eulerian_obj._map_single_delz,
+    ):
+        original_attributes[obj] = obj._lagrangian_contributions
+        obj._lagrangian_contributions = do_nothing  # type: ignore
+    for (
+        obj
+    ) in dynamical_core._lagrangian_to_eulerian_obj._mapn_tracer._list_of_remap_objects:
+        original_attributes[obj] = obj._lagrangian_contributions
+        obj._lagrangian_contributions = do_nothing  # type: ignore
+    try:
+        yield
+    finally:
+        for obj, original in original_attributes.items():
+            obj._lagrangian_contributions = original
+
+def parse_args() -> Namespace:
+    parser = ArgumentParser()
+
+    parser.add_argument(
+        "data_dir",
+        type=str,
+        action="store",
+        help="directory containing data to run with",
+    )
+    parser.add_argument(
+        "backend",
+        type=str,
+        action="store",
+        help="gt4py backend to use",
+    )
+   
+    return parser.parse_args()
+
+
+
+
+def setup_dycore(config, rank, backend) -> Tuple[fv3core.DynamicalCore, List[Any]]:
+    stencil_config = pace.dsl.stencil.StencilConfig(
+        backend=backend,
+        rebuild=False,
+        validate_args=True,
+    )
+   
+    mpi_comm = NullComm(
+        rank=rank, total_ranks=6 * config.layout[0] * config.layout[1], fill_value=0.0
+    )
+    partitioner = pace.util.CubedSpherePartitioner(
+        pace.util.TilePartitioner(config.layout)
+    )
+    communicator = pace.util.CubedSphereCommunicator(mpi_comm, partitioner)
+    sizer = pace.util.SubtileGridSizer.from_tile_params(
+        nx_tile=config.npx - 1,
+        ny_tile=config.npy - 1,
+        nz=config.npz,
+        n_halo=3,
+        extra_dim_lengths={},
+        layout=config.layout,
+        tile_partitioner=partitioner.tile,
+        tile_rank=communicator.tile.rank,
+    )
+    grid_indexing = pace.dsl.stencil.GridIndexing.from_sizer_and_communicator(
+        sizer=sizer, cube=communicator
+    )
+    quantity_factory = pace.util.QuantityFactory.from_backend(
+        sizer=sizer, backend=backend
+    )
+    metric_terms = MetricTerms(
+        quantity_factory=quantity_factory,
+        communicator=communicator,
+    )
+
+    # create an initial state from the Jablonowski & Williamson Baroclinic
+    # test case perturbation. JRMS2006
+    state = baroclinic_init.init_baroclinic_state(
+        metric_terms,
+        adiabatic=config.adiabatic,
+        hydrostatic=config.hydrostatic,
+        moist_phys=config.moist_phys,
+        comm=communicator,
+    )
+    stencil_factory = pace.dsl.stencil.StencilFactory(
+        config=stencil_config,
+        grid_indexing=grid_indexing,
+    )
+
+    dycore = fv3core.DynamicalCore(
+        comm=communicator,
+        grid_data=GridData.new_from_metric_terms(metric_terms),
+        stencil_factory=stencil_factory,
+        damping_coefficients=DampingCoefficients.new_from_metric_terms(metric_terms),
+        config=config,
+        phis=state.phis,
+    )
+    do_adiabatic_init = False
+    # TODO compute from namelist
+    bdt = config.dt_atmos
+
+    args = [
+        state,
+        config.consv_te,
+        do_adiabatic_init,
+        bdt,
+        config.n_split,
+    ]
+    return dycore, args
+
+if __name__ == "__main__":
+    args = parse_args()
+    namelist = f90nml.read(args.data_dir + "/input.nml")
+    dycore_config = DynamicalCoreConfig.from_f90nml(namelist)
+    for rank in range(dycore_config.layout[0] * dycore_config.layout[1]):
+        dycore, args = setup_dycore(dycore_config, rank, args.backend)
+        with no_lagrangian_contributions(dynamical_core=dycore):
+            dycore.step_dynamics(*args)

--- a/fv3core/examples/standalone/runfile/dynamics.py
+++ b/fv3core/examples/standalone/runfile/dynamics.py
@@ -214,8 +214,7 @@ def setup_dycore(
         util.TilePartitioner(dycore_config.layout)
     )
     communicator = util.CubedSphereCommunicator(mpi_comm, partitioner)
-
-    grid = Grid.from_namelist(dycore_config, rank, backend)
+    grid = Grid.from_namelist(dycore_config, mpi_comm.rank, backend)
     stencil_config = pace.dsl.stencil.StencilConfig(
         backend=backend,
         rebuild=False,
@@ -244,7 +243,7 @@ def setup_dycore(
         )
     else:
         state = read_serialized_initial_state(
-            rank, grid, dycore_config, stencil_factory
+            mpi_comm.rank, grid, dycore_config, stencil_factory
         )
     dycore = DynamicalCore(
         comm=communicator,


### PR DESCRIPTION
## Purpose

Since the daint upgrade, we haven't been able to compile multi-node, which could either be due to an issue with our distributed compilation, or a bug in the new cuda stack (gcc 10 no longer works with cuda 11.2). 
This introduces a dycore compiling script compile.py that will take the namelist we are testing and compile all the ranks in the first tile sequentially. For 6 ranks we can overload a node and do single node compilation, but this turned out to be slower than running them sequentially. But if we want to avoid running compile.py in our CI, I can branch on the number of ranks. 

## Code changes:

- added compile.py that runs the dycore with a null communicator and remapping replaced (to avoid the while loop running off the top of data that is nans) 
- updated run_on_daint to first run compile.py, then run the performance test. 
