### PR TITLE
Fix translate init tests

### DIFF
--- a/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -98,3 +98,15 @@ TrigSg:
 UtilVectors:
   - max_error: 5e-10 # 48_6ranks
     near_zero: 1e-13
+
+JablonowskiBaroclinic:
+  - ignore_near_zero_errors:
+      u: 4e-12
+      v: 4e-12
+    max_error: 3e-12
+
+InitCase:
+  - max_error: 7e-12
+    ignore_near_zero_errors:
+      u: 7e-12
+      v: 7e-12

--- a/fv3core/tests/savepoint/translate/translate_init_case.py
+++ b/fv3core/tests/savepoint/translate/translate_init_case.py
@@ -254,6 +254,7 @@ class TranslateInitPreJab(TranslateFortranData2Py):
             "eta_v": {"istart": 0, "iend": 0, "jstart": 0, "jend": 0},
         }
         self.namelist = namelist
+        self.stencil_factory = stencil_factory
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)
@@ -310,6 +311,7 @@ class TranslateJablonowskiBaroclinic(TranslateFortranData2Py):
 
         self.max_error = 1e-13
         self.namelist = namelist
+        self.stencil_factory = stencil_factory
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)
@@ -386,6 +388,7 @@ class TranslatePVarAuxiliaryPressureVars(TranslateFortranData2Py):
         for var in ["delz", "delp", "ps", "peln"]:
             self.out_vars[var] = self.in_vars["data_vars"][var]
         self.namelist = namelist
+        self.stencil_factory = stencil_factory
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)

--- a/stencils/pace/stencils/testing/translate.py
+++ b/stencils/pace/stencils/testing/translate.py
@@ -237,6 +237,12 @@ class TranslateGrid:
     composite_grid_vars = ["sin_sg", "cos_sg"]
     edge_var_axis = {"edge_w": 1, "edge_e": 1, "edge_s": 0, "edge_n": 0}
     ee_vars = ["ee1", "ee2", "ew1", "ew2", "es1", "es2"]
+    edge_vect_axis = {
+        "edge_vect_s": 0,
+        "edge_vect_n": 0,
+        "edge_vect_w": 1,
+        "edge_vect_e": 1,
+    }
     # Super (composite) grid
     #     9---4---8
     #     |       |
@@ -299,6 +305,23 @@ class TranslateGrid:
                     axis=axis,
                     read_only=True,
                     backend=self.backend,
+                )
+        for key, axis in TranslateGrid.edge_vect_axis.items():
+            if key in self.data:
+                mask = None
+                if axis == 1:
+                    default_origin = (0, 0)
+                    self.data[key] = self.data[key][np.newaxis, ...]
+                    self.data[key] = np.repeat(self.data[key], shape[0], axis=0)
+                if axis == 0:
+                    default_origin = (0,)
+                    mask = (True, False, False)
+                self.data[key] = utils.make_storage_data(
+                    data=self.data[key],
+                    origin=default_origin,
+                    shape=self.data[key].shape,
+                    backend=self.backend,
+                    mask=mask,
                 )
         for key, value in self.data.items():
             if type(value) is np.ndarray:


### PR DESCRIPTION
## Purpose

Since serialization savepoints are not part of the current serialized dataset (will be in the next release), some of the functionality has been broken due to infrastructure changes. This PR fixes issues with initialization savepoints.

## Code changes:

- Pass `stencil_factory` in each of `translate_init_case` savepoint class
- Add logic in `translate.py` to handle `edge_vect_*` variables 
- Add threshold override for `JablonowskiBaroclinic` and `InitCase`
    - this is needed to validate on different datasets (e.g., c192 54 ranks and 96 ranks)

## Infrastructure changes:

- To properly test this, we should move up to serialized data `7.2.7` or `8.0.0` along with the driver savepoint

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
