### PR TITLE
Transfer dace changes for fvtp2d/d_sw, remove CopiedCorners

### DIFF
--- a/fv3core/fv3core/stencils/d_sw.py
+++ b/fv3core/fv3core/stencils/d_sw.py
@@ -16,23 +16,13 @@ from fv3core.stencils.basic_operations import compute_coriolis_parameter_defn
 from fv3core.stencils.d2a2c_vect import contravariant
 from fv3core.stencils.delnflux import DelnFluxNoSG
 from fv3core.stencils.divergence_damping import DivergenceDamping
-from fv3core.stencils.fvtp2d import (
-    FiniteVolumeTransport,
-    PreAllocatedCopiedCornersFactory,
-)
+from fv3core.stencils.fvtp2d import FiniteVolumeTransport
 from fv3core.stencils.fxadv import FiniteVolumeFluxPrep
 from fv3core.stencils.xtp_u import advect_u_along_x
 from fv3core.stencils.ytp_v import advect_v_along_y
 from pace.dsl.stencil import StencilFactory
 from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
-from pace.util import (
-    X_DIM,
-    X_INTERFACE_DIM,
-    Y_DIM,
-    Y_INTERFACE_DIM,
-    Z_DIM,
-    Z_INTERFACE_DIM,
-)
+from pace.util import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from pace.util.grid import DampingCoefficients, GridData
 
 
@@ -958,11 +948,6 @@ class DGridShallowWaterLagrangianDynamics:
             origin=self.grid_indexing.origin,
             backend=stencil_factory.backend,
         )
-        self._copy_corners = PreAllocatedCopiedCornersFactory(
-            stencil_factory,
-            dims=[X_DIM, Y_DIM, Z_INTERFACE_DIM],
-            y_temporary=y_temporary,
-        )
 
     def __call__(
         self,
@@ -1039,7 +1024,7 @@ class DGridShallowWaterLagrangianDynamics:
         # apply them in various similar stencils - can these steps be merged?
 
         self.fvtp2d_dp(
-            self._copy_corners(delp),
+            delp,
             crx,
             cry,
             xfx,
@@ -1082,7 +1067,7 @@ class DGridShallowWaterLagrangianDynamics:
             )
 
             self.fvtp2d_vt_nodelnflux(
-                self._copy_corners(w),
+                w,
                 crx,
                 cry,
                 xfx,
@@ -1102,7 +1087,7 @@ class DGridShallowWaterLagrangianDynamics:
             )
         # Fortran: #ifdef USE_COND
         self.fvtp2d_dp_t(
-            self._copy_corners(q_con),
+            q_con,
             crx,
             cry,
             xfx,
@@ -1120,7 +1105,7 @@ class DGridShallowWaterLagrangianDynamics:
 
         # Fortran #endif //USE_COND
         self.fvtp2d_tm(
-            self._copy_corners(pt),
+            pt,
             crx,
             cry,
             xfx,
@@ -1214,7 +1199,7 @@ class DGridShallowWaterLagrangianDynamics:
         self._compute_vort_stencil(self._vorticity_agrid, self._f0, zh, self._tmp_vort)
 
         self.fvtp2d_vt_nodelnflux(
-            self._copy_corners(self._tmp_vort),
+            self._tmp_vort,
             crx,
             cry,
             xfx,

--- a/fv3core/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/fv3core/stencils/tracer_2d_1l.py
@@ -5,10 +5,7 @@ from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
 import pace.dsl.gt4py_utils as utils
 import pace.util
-from fv3core.stencils.fvtp2d import (
-    FiniteVolumeTransport,
-    PreAllocatedCopiedCornersFactory,
-)
+from fv3core.stencils.fvtp2d import FiniteVolumeTransport
 from pace.dsl.stencil import StencilFactory
 from pace.dsl.typing import FloatField, FloatFieldIJ
 
@@ -248,11 +245,6 @@ class TracerAdvection:
         self._tracers_halo_updater = self.comm.get_scalar_halo_updater(
             [tracer_halo_spec] * tracer_count
         )
-        self._copy_corners = PreAllocatedCopiedCornersFactory(
-            stencil_factory=stencil_factory,
-            dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
-            y_temporary=None,
-        )
 
     def __call__(self, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt):
         """
@@ -344,7 +336,7 @@ class TracerAdvection:
             )
             for q in tracers.values():
                 self.finite_volume_transport(
-                    self._copy_corners(q.storage),
+                    q.storage,
                     cxd,
                     cyd,
                     self._tmp_xfx,

--- a/fv3core/fv3core/stencils/updatedzd.py
+++ b/fv3core/fv3core/stencils/updatedzd.py
@@ -2,13 +2,9 @@ import gt4py.gtscript as gtscript
 from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import pace.dsl.gt4py_utils as utils
-import pace.util
 import pace.util.constants as constants
 from fv3core.stencils.delnflux import DelnFluxNoSG
-from fv3core.stencils.fvtp2d import (
-    FiniteVolumeTransport,
-    PreAllocatedCopiedCornersFactory,
-)
+from fv3core.stencils.fvtp2d import FiniteVolumeTransport
 from pace.dsl.stencil import GridIndexing, StencilFactory
 from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
 from pace.util.grid import DampingCoefficients, GridData
@@ -325,11 +321,6 @@ class UpdateHeightOnDGrid:
         self._gamma = utils.make_storage_data(
             gamma_3d[0, 0, :], gamma_3d.shape[2:], (0,), backend=stencil_factory.backend
         )
-        self._copy_corners = PreAllocatedCopiedCornersFactory(
-            stencil_factory=stencil_factory,
-            dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_INTERFACE_DIM],
-            y_temporary=None,
-        )
 
     def __call__(
         self,
@@ -371,7 +362,7 @@ class UpdateHeightOnDGrid:
             y_area_flux, self._y_area_flux_interface, self._gk, self._beta, self._gamma
         )
         self.finite_volume_transport(
-            self._copy_corners(height),
+            height,
             self._crx_interface,
             self._cry_interface,
             self._x_area_flux_interface,

--- a/fv3core/tests/savepoint/translate/translate_fvtp2d.py
+++ b/fv3core/tests/savepoint/translate/translate_fvtp2d.py
@@ -1,10 +1,6 @@
 import pace.dsl.gt4py_utils as utils
-from fv3core.stencils.fvtp2d import (
-    FiniteVolumeTransport,
-    PreAllocatedCopiedCornersFactory,
-)
+from fv3core.stencils.fvtp2d import FiniteVolumeTransport
 from pace.stencils.testing import TranslateFortranData2Py
-from pace.util import X_DIM, Y_DIM, Z_DIM
 
 
 class TranslateFvTp2d(TranslateFortranData2Py):
@@ -60,13 +56,7 @@ class TranslateFvTp2d(TranslateFortranData2Py):
             damp_c=inputs.pop("damp_c"),
         )
         del inputs["hord"]
-        q_storage = inputs["q"]
-        factory = PreAllocatedCopiedCornersFactory(
-            self.stencil_factory, dims=[X_DIM, Y_DIM, Z_DIM], y_temporary=None
-        )
-        inputs["q"] = factory(q_storage)
         self.compute_func(**inputs)
-        inputs["q"] = q_storage
         return inputs
 
 


### PR DESCRIPTION
## Purpose

This PR fixes issues in fvtp2d and d_sw that prevent the code from working with DaCe.

## Code changes:

- Removed CopiedCorners and PreAllocatedCopiedCornersFactory
- use boolean for do_delnflux inside FiniteVolumeTransport

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes
