### PR TITLE
Clean up concrete externals for fv3core, even on failure

### DIFF
--- a/fv3core/docker/concrete_externals.sh
+++ b/fv3core/docker/concrete_externals.sh
@@ -4,6 +4,27 @@ command=$1
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
+function cleanup {
+  echo "Restoring fv3core symlinks"
+  rm -r $SCRIPT_DIR/../external/pace-util
+  rm -r $SCRIPT_DIR/../external/stencils
+  rm -r $SCRIPT_DIR/../external/gt4py
+  rm -r $SCRIPT_DIR/../external/dsl
+  rm $SCRIPT_DIR/../constraints.txt
+
+  cd $SCRIPT_DIR
+  ln -s ../../pace-util ../external/pace-util
+  ln -s ../../stencils ../external/stencils
+  ln -s ../../external/gt4py ../external/gt4py
+  ln -s ../../dsl ../external/dsl
+  cd $SCRIPT_DIR/..
+  ln -s ../constraints.txt constraints.txt
+}
+
+trap cleanup EXIT
+
+echo "Replacing fv3core symlinks with concrete files"
+
 rm $SCRIPT_DIR/../external/pace-util
 cp -r $SCRIPT_DIR/../../pace-util $SCRIPT_DIR/../external/pace-util
 
@@ -23,18 +44,5 @@ echo $command
 eval $command
 
 ret=$?
-
-rm -r $SCRIPT_DIR/../external/pace-util
-rm -r $SCRIPT_DIR/../external/stencils
-rm -r $SCRIPT_DIR/../external/gt4py
-rm -r $SCRIPT_DIR/../external/dsl
-rm $SCRIPT_DIR/../constraints.txt
-
-cd $SCRIPT_DIR
-ln -s ../../pace-util ../external/pace-util
-ln -s ../../stencils ../external/stencils
-ln -s ../../stencils ../external/gt4py
-ln -s ../../dsl ../external/dsl
-ln -s ../../constraints.txt ../constraints.txt
 
 exit $ret


### PR DESCRIPTION
## Purpose

concrete_externals.sh currently symlinks the wrong location to fv3core/external/gt4py, and does not consistently restore symlinks on cleanup. This PR fixes those issues.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
