### PR TITLE
Update grid thresholds for higher resolution

### DIFF
--- a/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -40,22 +40,23 @@ DivgDel6:
  - max_error: 3e-12 # 48_6ranks
 
 DxDy:
- - max_error: 4e-13 # 48_6ranks
+ - max_error: 6e-13 # 48_6ranks
 
 EdgeFactors:
  - max_error: 3e-11 # 48_6ranks
 
 DerivedTrig:
- - max_error: 7e-11 # 48_6ranks
-
-GridAreas:
- - max_error: 1e-10 # 48_6ranks
+ - max_error: 7e-11 # 192_6ranks
+   near_zero: 1.1e-4
+   ignore_near_zero_errors:
+      - ee1
+      - ee2
 
 GridGrid:
- - max_error: 2e-12 # 48_6ranks
+ - max_error: 2e-11 # 192_6ranks
 
 InitGrid:
- - max_error: 5e-11 # 48_6ranks
+ - max_error: 1e-10 # 192_6ranks
 
 InitGridUtils:
  - max_error: 5e-6 # 48_6ranks
@@ -97,7 +98,7 @@ TrigSg:
 
 UtilVectors:
   - max_error: 5e-10 # 48_6ranks
-    near_zero: 1e-13
+    near_zero: 5e-5
 
 JablonowskiBaroclinic:
   - ignore_near_zero_errors:

--- a/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -49,7 +49,7 @@ DerivedTrig:
  - max_error: 7e-11 # 48_6ranks
 
 GridAreas:
- - max_error: 5e-11 # 48_6ranks
+ - max_error: 1e-10 # 48_6ranks
 
 GridGrid:
  - max_error: 2e-12 # 48_6ranks

--- a/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -46,11 +46,7 @@ EdgeFactors:
  - max_error: 3e-11 # 48_6ranks
 
 DerivedTrig:
- - max_error: 7e-11 # 192_6ranks
-   near_zero: 1.1e-4
-   ignore_near_zero_errors:
-      - ee1
-      - ee2
+ - max_error: 2e-9 # 192_6ranks
 
 GridGrid:
  - max_error: 2e-11 # 192_6ranks
@@ -94,8 +90,7 @@ TrigSg:
       - cos_sg9
 
 UtilVectors:
-  - max_error: 5e-10 # 48_6ranks
-    near_zero: 5e-5
+  - max_error: 2e-8 # 192_6ranks
 
 JablonowskiBaroclinic:
   - ignore_near_zero_errors:

--- a/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -55,9 +55,6 @@ DerivedTrig:
 GridGrid:
  - max_error: 2e-11 # 192_6ranks
 
-InitGrid:
- - max_error: 1e-10 # 192_6ranks
-
 InitGridUtils:
  - max_error: 5e-6 # 48_6ranks
    near_zero: 5e-8

--- a/fv3core/tests/savepoint/translate/translate_grid.py
+++ b/fv3core/tests/savepoint/translate/translate_grid.py
@@ -471,7 +471,7 @@ class TranslateInitGrid(ParallelTranslateGrid):
 
     def __init__(self, grids, namelist, stencil_factory):
         super().__init__(grids, namelist, stencil_factory)
-        self.max_error = 3e-12
+        self.max_error = 1e-10
         self.near_zero = 3e-14
         self.ignore_near_zero_errors = {"gridvar": True, "agrid": True}
         self.stencil_factory = stencil_factory

--- a/fv3core/tests/savepoint/translate/translate_grid.py
+++ b/fv3core/tests/savepoint/translate/translate_grid.py
@@ -471,7 +471,7 @@ class TranslateInitGrid(ParallelTranslateGrid):
 
     def __init__(self, grids, namelist, stencil_factory):
         super().__init__(grids, namelist, stencil_factory)
-        self.max_error = 1e-10
+        self.max_error = 3e-12
         self.near_zero = 3e-14
         self.ignore_near_zero_errors = {"gridvar": True, "agrid": True}
         self.stencil_factory = stencil_factory
@@ -571,7 +571,7 @@ class TranslateUtilVectors(ParallelTranslateGrid):
     def __init__(self, grids, namelist, stencil_factory):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 3e-12
-        self.near_zero = 2e-6
+        self.near_zero = 1e-13
         self.ignore_near_zero_errors = {
             "ew1": True,
             "ew2": True,
@@ -1043,7 +1043,7 @@ class TranslateDerivedTrig(ParallelTranslateGrid):
     def __init__(self, grids, namelist, stencil_factory):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 8.5e-14
-        self.near_zero = 3e-6
+        self.near_zero = 3e-14
         self.ignore_near_zero_errors = {"ee1": True, "ee2": True}
         self._base.in_vars["data_vars"] = {
             "ee1": {

--- a/fv3core/tests/savepoint/translate/translate_grid.py
+++ b/fv3core/tests/savepoint/translate/translate_grid.py
@@ -571,12 +571,14 @@ class TranslateUtilVectors(ParallelTranslateGrid):
     def __init__(self, grids, namelist, stencil_factory):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 3e-12
-        self.near_zero = 3e-14
+        self.near_zero = 2e-6
         self.ignore_near_zero_errors = {
             "ew1": True,
             "ew2": True,
             "es1": True,
             "es2": True,
+            "ec1": True,
+            "ec2": True,
         }
         self._base.in_vars["data_vars"] = {
             "ec1": {
@@ -1041,7 +1043,7 @@ class TranslateDerivedTrig(ParallelTranslateGrid):
     def __init__(self, grids, namelist, stencil_factory):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 8.5e-14
-        self.near_zero = 3e-14
+        self.near_zero = 3e-6
         self.ignore_near_zero_errors = {"ee1": True, "ee2": True}
         self._base.in_vars["data_vars"] = {
             "ee1": {

--- a/fv3core/tests/savepoint/translate/translate_grid.py
+++ b/fv3core/tests/savepoint/translate/translate_grid.py
@@ -121,7 +121,7 @@ class TranslateMirrorGrid(ParallelTranslateGrid):
 class TranslateGridAreas(ParallelTranslateGrid):
     def __init__(self, rank_grids, namelist, stencil_factory):
         super().__init__(rank_grids, namelist, stencil_factory)
-        self.max_error = 3e-12
+        self.max_error = 1e-10
         self.near_zero = 3e-14
         self.ignore_near_zero_errors = {"agrid": True, "dxc": True, "dyc": True}
         self.stencil_factory = stencil_factory


### PR DESCRIPTION
## Purpose

This PR adjusts the validation thresholds for the grid initialization code for higher resolution runs.

## Code changes:

- `fv3core/tests/savepoint/translate/overrides/baroclinic.yaml`: Updated validation threshold for GridGrid, removed threshold for InitGrid and near-zero definitions for UtilVectors and DerivedTrig. GridGrid fails on roughly two points, possibly due to a near-zero issue (`10^-4`) but I haven't tracked it down satisfactorily. InitGrid now has understood, larger errors, and the updated thresholds in UtilVectors and DerivedTrig likely reflect the same issues at C48
- `fv3core/tests/savepoint/translate/translate_grid.py`: Updated validation threshold for GridAreas and the near-zero definitions for UtilVectors. The GridAreas validation issue comes from a small error being multiplied by the Earth's radius squared, wile the UtilVectors and DerivedTrig are small errors `~10^-15` at points valued at `10^-15` or `10^-14`.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
