### PR TITLE
Pin click version when running black in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,8 @@ repos:
 -   repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:
-    -   id: black
+    - id: black
+      additional_dependencies: ["click==8.0.4"]
 
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.4.2


### PR DESCRIPTION
## Purpose

The latest version of click breaks black. This PR adds a pin of click to the last version of the breaking change in our pre-commit configuration, to avoid breaking pre-commit on new installations.

## Requirements changes:

- Pinned version of click used within pre-commit for black to 8.0.4

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
