### PR TITLE
Format source when using numpy backend

### DIFF
--- a/fv3core/tests/savepoint/conftest.py
+++ b/fv3core/tests/savepoint/conftest.py
@@ -96,6 +96,7 @@ def stencil_config(backend):
         backend=backend,
         rebuild=False,
         validate_args=True,
+        format_source="numpy" in backend,
     )
 
 


### PR DESCRIPTION
## Purpose

In the tests, format the generated numpy source when using the gtc:numpy debug backend.

## Code changes:

- Sets `format_source = True` for tests when using backend with numpy in their name.
