### PR TITLE
Add a configuration option to driver to disable step_physics call

### DIFF
--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -57,6 +57,10 @@ class DriverConfig:
         minutes: minutes to add to total simulation time
         seconds: seconds to add to total simulation time
         dycore_only: whether to run just the dycore, or physics too
+        disable_step_physics: whether to completely disable the step_physics call,
+            including coupling code between the dycore and physics, as well as
+            dry static adjustment. This is a development flag and will be removed
+            in a later commit.
     """
 
     stencil_config: pace.dsl.StencilConfig
@@ -80,6 +84,7 @@ class DriverConfig:
     minutes: int = 0
     seconds: int = 0
     dycore_only: bool = False
+    disable_step_physics: bool = False
 
     @functools.cached_property
     def timestep(self) -> timedelta:
@@ -253,7 +258,8 @@ class Driver:
     def _step(self, timestep: float):
         with self.performance_config.timestep_timer.clock("mainloop"):
             self._step_dynamics(timestep=timestep)
-            self._step_physics(timestep=timestep)
+            if not self.config.disable_step_physics:
+                self._step_physics(timestep=timestep)
 
         self.performance_config.collect_performance()
 


### PR DESCRIPTION
## Purpose

In our EAC run, we plan to disable the coupler code. This PR adds a commit which makes this possible to configure without code edits.

## Code changes:

- Added disable_step_physics option to DriverConfig

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
