### PR TITLE
util/v0.8.0 + zarr monitor: allow transposed diagnostics to be written

### DIFF
--- a/fv3gfs-physics/tests/savepoint/translate/translate_driver.py
+++ b/fv3gfs-physics/tests/savepoint/translate/translate_driver.py
@@ -10,7 +10,7 @@ from fv3core.testing.translate_fvdynamics import TranslateFVDynamics
 from fv3core.testing.validation import enable_selective_validation
 from fv3gfs.physics import PhysicsConfig, PhysicsState
 from pace.driver.run import Driver, DriverConfig
-from pace.driver.tendency_state import TendencyState
+from pace.driver.state import TendencyState
 from pace.util.namelist import Namelist
 
 

--- a/pace-util/HISTORY.md
+++ b/pace-util/HISTORY.md
@@ -5,6 +5,7 @@ latest
 ------
 
 Major changes:
+- Changed `ZarrMonitor` store behavior to allow passing chunks with different dimension orders
 - Added `CachingCommWriter` which wraps a `Comm` object and can be serialized to a file-like object with a `.dump` method
 - Added `CachingCommReader` which can be loaded from the dump output of `CachingCommWriter` and replays its communication in the order it occurred.
 - `NullComm` is now public api in `pace-util`

--- a/pace-util/HISTORY.md
+++ b/pace-util/HISTORY.md
@@ -4,6 +4,9 @@ History
 latest
 ------
 
+v0.8.0
+------
+
 Major changes:
 - Changed `ZarrMonitor.store` behavior to allow passing quantities with different dimension orders
 - Added `CachingCommWriter` which wraps a `Comm` object and can be serialized to a file-like object with a `.dump` method

--- a/pace-util/HISTORY.md
+++ b/pace-util/HISTORY.md
@@ -5,7 +5,7 @@ latest
 ------
 
 Major changes:
-- Changed `ZarrMonitor` store behavior to allow passing chunks with different dimension orders
+- Changed `ZarrMonitor.store` behavior to allow passing quantities with different dimension orders
 - Added `CachingCommWriter` which wraps a `Comm` object and can be serialized to a file-like object with a `.dump` method
 - Added `CachingCommReader` which can be loaded from the dump output of `CachingCommWriter` and replays its communication in the order it occurred.
 - `NullComm` is now public api in `pace-util`

--- a/pace-util/pace/util/__init__.py
+++ b/pace-util/pace/util/__init__.py
@@ -58,5 +58,5 @@ from .units import UnitsError, ensure_equal_units, units_are_equal
 from .zarr_monitor import ZarrMonitor
 
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 __all__ = list(key for key in locals().keys() if not key.startswith("_"))

--- a/pace-util/pace/util/zarr_monitor.py
+++ b/pace-util/pace/util/zarr_monitor.py
@@ -121,8 +121,9 @@ class ZarrMonitor:
         Requires the state contain the same quantities with the same metadata as the
         first time this is called. Dimension order metadata may change between calls
         so long as the set of dimsensions is the same. Quantities are stored with
-        dimensions [time, rank] followed by the dimensions included in any one state
-        snapshot. The one exception is "time" which is stored with dimensions [time].
+        dimensions [time, rank] followed by the dimensions included in the first
+        state snapshot. The one exception is "time" which is stored with dimensions
+        [time].
         """
         self._ensure_writers_are_consistent(state)
         for name, quantity in sorted(state.items(), key=lambda x: x[0]):
@@ -266,12 +267,6 @@ class _ZarrVariableWriter:
             "_ARRAY_DIMENSIONS": list(self._PREPEND_DIMS + quantity.dims),
             **quantity.attrs,
         }
-
-    def _order_dims(self, quantity):
-        if self.array is None:
-            return quantity
-        else:
-            dim_order = self.array.attrs["_ARRAY_DIMENSIONS"]
 
     def _ensure_compatible_attrs(self, new_quantity):
         new_attrs = self._get_attrs(new_quantity)

--- a/pace-util/pace/util/zarr_monitor.py
+++ b/pace-util/pace/util/zarr_monitor.py
@@ -119,9 +119,10 @@ class ZarrMonitor:
         """Append the model state dictionary to the zarr store.
 
         Requires the state contain the same quantities with the same metadata as the
-        first time this is called. Quantities are stored with dimensions [time, rank]
-        followed by the dimensions included in any one state snapshot. The one exception
-        is "time" which is stored with dimensions [time].
+        first time this is called. Dimension order metadata may change between calls
+        so long as the set of dimsensions is the same. Quantities are stored with
+        dimensions [time, rank] followed by the dimensions included in any one state
+        snapshot. The one exception is "time" which is stored with dimensions [time].
         """
         self._ensure_writers_are_consistent(state)
         for name, quantity in sorted(state.items(), key=lambda x: x[0]):

--- a/pace-util/pace/util/zarr_monitor.py
+++ b/pace-util/pace/util/zarr_monitor.py
@@ -120,7 +120,7 @@ class ZarrMonitor:
 
         Requires the state contain the same quantities with the same metadata as the
         first time this is called. Dimension order metadata may change between calls
-        so long as the set of dimsensions is the same. Quantities are stored with
+        so long as the set of dimensions is the same. Quantities are stored with
         dimensions [time, rank] followed by the dimensions included in the first
         state snapshot. The one exception is "time" which is stored with dimensions
         [time].

--- a/pace-util/setup.cfg
+++ b/pace-util/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.8.0
 commit = True
 
 [bdist_wheel]

--- a/pace-util/setup.py
+++ b/pace-util/setup.py
@@ -23,8 +23,8 @@ with open("HISTORY.md") as history_file:
     history = history_file.read()
 
 setup(
-    author="Vulcan Technologies LLC",
-    author_email="jeremym@vulcan.com",
+    author="Allen Institute of Artificial Intelligence",
+    author_email="jeremym@allenai.org",
     python_requires=">=3.8",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/pace-util/setup.py
+++ b/pace-util/setup.py
@@ -48,6 +48,6 @@ setup(
     packages=find_namespace_packages(include=["pace.*"]),
     include_package_data=True,
     url="https://github.com/ai2cm/pace",
-    version="0.7.0",
+    version="0.8.0",
     zip_safe=False,
 )

--- a/pace-util/tests/test_zarr_monitor.py
+++ b/pace-util/tests/test_zarr_monitor.py
@@ -19,12 +19,16 @@ import copy
 import logging
 
 import pace.util
+from pace.util import X_DIMS, Y_DIMS
 from pace.util.testing import DummyComm
 
 
 requires_zarr = pytest.mark.skipif(zarr is None, reason="zarr is not installed")
 
 logger = logging.getLogger("test_zarr_monitor")
+
+# pace's Z_DIMS doesn't check the soil dimension
+Z_DIMS = ("z", "z_interface", "z_soil")
 
 
 @pytest.fixture(params=["one_step", "three_steps"])
@@ -394,3 +398,74 @@ def test_monitor_file_store_inconsistent_calendars(
         monitor.store(initial_state)
         with pytest.raises(ValueError, match="Calendar type"):
             monitor.store(final_state)
+
+
+@pytest.fixture(
+    params=[
+        ["x", "y"],
+        ["x", "y", "z"],
+        ["x_interface", "y", "z"],
+        ["x", "y_interface", "z"],
+        ["x", "y", "z_soil"],
+    ],
+)
+def diag(request, numpy):
+    dims = request.param
+    diag = pace.util.Quantity(
+        numpy.ones([size + 2 for size in range(len(dims))]), dims=dims, units="m"
+    )
+    return diag
+
+
+def _transpose(quantity, dims_2d=[X_DIMS, Y_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]):
+    if len(quantity.dims) == 2:
+        return quantity.transpose(dims_2d)
+    elif len(quantity.dims) == 3:
+        return quantity.transpose(dims_3d)
+
+
+def test_transposed_diags_write_across_ranks(diag, cube_partitioner, tmpdir_factory):
+
+    layout = (1, 1)
+    total_ranks = 6 * layout[0] * layout[1]
+    tmpdir = tmpdir_factory.mktemp("data.zarr")
+    store = zarr.storage.DirectoryStore(tmpdir)
+    shared_buffer = {}
+    for rank in range(total_ranks):
+        monitor = pace.util.ZarrMonitor(
+            store,
+            cube_partitioner,
+            mpi_comm=DummyComm(
+                rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
+            ),
+        )
+        if rank % 2 == 0:
+            diag_to_store = _transpose(
+                diag, dims_2d=[Y_DIMS, X_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]
+            )
+        else:
+            diag_to_store = _transpose(
+                diag, dims_2d=[X_DIMS, Y_DIMS], dims_3d=[Y_DIMS, X_DIMS, Z_DIMS]
+            )
+        # verify that we can store transposed diags across ranks
+        monitor.store({"a": diag_to_store})
+
+
+def test_transposed_diags_write_across_timesteps(
+    diag, cube_partitioner, tmpdir_factory
+):
+
+    tmpdir = tmpdir_factory.mktemp("data.zarr")
+    store = zarr.storage.DirectoryStore(tmpdir)
+    monitor = pace.util.ZarrMonitor(store, cube_partitioner)
+    # verify that we can store transposed diags across time
+    time_1 = cftime.DatetimeJulian(2010, 6, 20, 6, 0, 0)
+    diag_1 = _transpose(
+        diag, dims_2d=[Y_DIMS, X_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]
+    )
+    monitor.store({"time": time_1, "a": diag_1})
+    time_2 = cftime.DatetimeJulian(2010, 6, 20, 6, 15, 0)
+    diag_2 = _transpose(
+        diag, dims_2d=[X_DIMS, Y_DIMS], dims_3d=[Y_DIMS, X_DIMS, Z_DIMS]
+    )
+    monitor.store({"time": time_2, "a": diag_2})

--- a/pace-util/tests/test_zarr_monitor.py
+++ b/pace-util/tests/test_zarr_monitor.py
@@ -417,7 +417,7 @@ def diag(request, numpy):
     return diag
 
 
-def _transpose(quantity, dims_2d=[Y_DIMS, X_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]):
+def _transpose(quantity, dims_2d, dims_3d):
     if len(quantity.dims) == 2:
         return quantity.transpose(dims_2d)
     elif len(quantity.dims) == 3:
@@ -441,7 +441,9 @@ def test_transposed_diags_write_across_ranks(diag, cube_partitioner, tmpdir_fact
             ),
         )
         if rank % 2 == 0:
-            diag_to_store = _transpose(diag)
+            diag_to_store = _transpose(
+                diag, dims_2d=[Y_DIMS, X_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]
+            )
         else:
             diag_to_store = _transpose(
                 diag, dims_2d=[X_DIMS, Y_DIMS], dims_3d=[X_DIMS, Y_DIMS, Z_DIMS]
@@ -460,7 +462,9 @@ def test_transposed_diags_write_across_timesteps(
     monitor = pace.util.ZarrMonitor(store, cube_partitioner)
     # verify that we can store transposed diags across time
     time_1 = cftime.DatetimeJulian(2010, 6, 20, 6, 0, 0)
-    diag_1 = _transpose(diag)
+    diag_1 = _transpose(
+        diag, dims_2d=[Y_DIMS, X_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]
+    )
     monitor.store({"time": time_1, "a": diag_1})
     time_2 = cftime.DatetimeJulian(2010, 6, 20, 6, 15, 0)
     diag_2 = _transpose(

--- a/pace-util/tests/test_zarr_monitor.py
+++ b/pace-util/tests/test_zarr_monitor.py
@@ -424,6 +424,7 @@ def _transpose(quantity, dims_2d=[Y_DIMS, X_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DI
         return quantity.transpose(dims_3d)
 
 
+@requires_zarr
 def test_transposed_diags_write_across_ranks(diag, cube_partitioner, tmpdir_factory):
 
     layout = (1, 1)
@@ -449,6 +450,7 @@ def test_transposed_diags_write_across_ranks(diag, cube_partitioner, tmpdir_fact
         monitor.store({"a": diag_to_store})
 
 
+@requires_zarr
 def test_transposed_diags_write_across_timesteps(
     diag, cube_partitioner, tmpdir_factory
 ):

--- a/pace-util/tests/test_zarr_monitor.py
+++ b/pace-util/tests/test_zarr_monitor.py
@@ -417,7 +417,7 @@ def diag(request, numpy):
     return diag
 
 
-def _transpose(quantity, dims_2d=[X_DIMS, Y_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]):
+def _transpose(quantity, dims_2d=[Y_DIMS, X_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]):
     if len(quantity.dims) == 2:
         return quantity.transpose(dims_2d)
     elif len(quantity.dims) == 3:
@@ -440,12 +440,10 @@ def test_transposed_diags_write_across_ranks(diag, cube_partitioner, tmpdir_fact
             ),
         )
         if rank % 2 == 0:
-            diag_to_store = _transpose(
-                diag, dims_2d=[Y_DIMS, X_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]
-            )
+            diag_to_store = _transpose(diag)
         else:
             diag_to_store = _transpose(
-                diag, dims_2d=[X_DIMS, Y_DIMS], dims_3d=[Y_DIMS, X_DIMS, Z_DIMS]
+                diag, dims_2d=[X_DIMS, Y_DIMS], dims_3d=[X_DIMS, Y_DIMS, Z_DIMS]
             )
         # verify that we can store transposed diags across ranks
         monitor.store({"a": diag_to_store})
@@ -460,12 +458,10 @@ def test_transposed_diags_write_across_timesteps(
     monitor = pace.util.ZarrMonitor(store, cube_partitioner)
     # verify that we can store transposed diags across time
     time_1 = cftime.DatetimeJulian(2010, 6, 20, 6, 0, 0)
-    diag_1 = _transpose(
-        diag, dims_2d=[Y_DIMS, X_DIMS], dims_3d=[Z_DIMS, Y_DIMS, X_DIMS]
-    )
+    diag_1 = _transpose(diag)
     monitor.store({"time": time_1, "a": diag_1})
     time_2 = cftime.DatetimeJulian(2010, 6, 20, 6, 15, 0)
     diag_2 = _transpose(
-        diag, dims_2d=[X_DIMS, Y_DIMS], dims_3d=[Y_DIMS, X_DIMS, Z_DIMS]
+        diag, dims_2d=[X_DIMS, Y_DIMS], dims_3d=[X_DIMS, Y_DIMS, Z_DIMS]
     )
     monitor.store({"time": time_2, "a": diag_2})


### PR DESCRIPTION
## Purpose

The zarr monitor currently ascertains the metadata of the variable to be written from the first chunk (in rank or time) that it receives, and assumes all future chunks will have the same metadata including dimension order. Thus it fails if an upstream process transposes a subsequent chunk (e.g., https://github.com/ai2cm/fv3net/issues/1767) , but it has the needed information to handle this case. This PR allows for dimension order changes in diagnostic chunks so long as the other metadata stays the same across chunks. 

Also updates `pace-util` to `v0.8.0`.

## Code changes:

- `ZarrMonitor.store` now allow for transposing inputs to match previously stored dimension order, if inputs have same set of dimensions but in different order.

## Checklist
Before submitting this PR, please make sure:

- [X] Docstrings and type hints are added to new and updated routines, as appropriate
- [X] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [X] For each public change and fix in `pace-util`, HISTORY has been updated
- [X] Unit tests are added or updated for non-stencil code changes
