### PR TITLE
disable driver diagnostics if no path given

### DIFF
--- a/driver/pace/driver/diagnostics.py
+++ b/driver/pace/driver/diagnostics.py
@@ -1,6 +1,7 @@
+import abc
 import dataclasses
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 import zarr.storage
 
@@ -14,29 +15,69 @@ from pace.util.quantity import QuantityMetadata
 from .state import DriverState
 
 
+class Diagnostics(abc.ABC):
+    @abc.abstractmethod
+    def store(self, time: datetime, state: DriverState):
+        ...
+
+    @abc.abstractmethod
+    def store_grid(
+        self, grid_data: pace.util.grid.GridData, metadata: QuantityMetadata
+    ):
+        ...
+
+
 @dataclasses.dataclass(frozen=True)
 class DiagnosticsConfig:
-    path: str
+    """
+    Attributes:
+        path: location to save diagnostics if given, otherwise no diagnostics
+            will be stored
+        names: diagnostics to save
+    """
+
+    path: Optional[str] = None
     names: List[str] = dataclasses.field(default_factory=list)
 
+    def diagnostics_factory(
+        self, partitioner: pace.util.CubedSpherePartitioner, comm
+    ) -> Diagnostics:
+        """
+        Create a diagnostics object.
 
-class Diagnostics:
+        Args:
+            partitioner: defines the grid on which diagnostics are stored
+            comm: an mpi4py-style communicator required to coordinate the
+                storage of the diagnostics
+        """
+        if self.path is None:
+            return NullDiagnostics()
+        else:
+            return ZarrDiagnostics(
+                path=self.path, names=self.names, partitioner=partitioner, comm=comm
+            )
+
+
+class ZarrDiagnostics(Diagnostics):
+    """Diagnostics that saves to a zarr store."""
+
     def __init__(
         self,
-        config: DiagnosticsConfig,
+        path: str,
+        names: List[str],
         partitioner: pace.util.CubedSpherePartitioner,
         comm,
     ):
-        self.config = config
-        store = zarr.storage.DirectoryStore(path=self.config.path)
+        self.names = names
+        store = zarr.storage.DirectoryStore(path=path)
         self.monitor = pace.util.ZarrMonitor(
             store=store, partitioner=partitioner, mpi_comm=comm
         )
 
     def store(self, time: datetime, state: DriverState):
-        if len(self.config.names) > 0:
+        if len(self.names) > 0:
             zarr_state = {"time": time}
-            for name in self.config.names:
+            for name in self.names:
                 try:
                     quantity = getattr(state.dycore_state, name)
                 except AttributeError:
@@ -59,3 +100,15 @@ class Diagnostics:
             )
             zarr_grid[name] = grid_quantity
         self.monitor.store_constant(zarr_grid)
+
+
+class NullDiagnostics(Diagnostics):
+    """Diagnostics that do nothing."""
+
+    def store(self, time: datetime, state: DriverState):
+        pass
+
+    def store_grid(
+        self, grid_data: pace.util.grid.GridData, metadata: QuantityMetadata
+    ):
+        pass

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -231,8 +231,7 @@ class Driver:
                 dycore_only=self.config.dycore_only,
                 apply_tendencies=self.config.apply_tendencies,
             )
-            self.diagnostics = diagnostics.Diagnostics(
-                config=config.diagnostics_config,
+            self.diagnostics = config.diagnostics_config.diagnostics_factory(
                 partitioner=communicator.partitioner,
                 comm=self.comm,
             )

--- a/driver/tests/test_diagnostics_config.py
+++ b/driver/tests/test_diagnostics_config.py
@@ -1,0 +1,26 @@
+import unittest.mock
+
+import pace.driver
+from pace.driver.diagnostics import NullDiagnostics
+
+
+def test_returns_null_diagnostics_if_no_path_given():
+    config = pace.driver.DiagnosticsConfig(path=None, names=["foo"])
+    assert isinstance(
+        config.diagnostics_factory(
+            unittest.mock.MagicMock(), unittest.mock.MagicMock()
+        ),
+        NullDiagnostics,
+    )
+
+
+def test_returns_zarr_diagnostics_if_path_given(tmpdir):
+    config = pace.driver.DiagnosticsConfig(path=tmpdir, names=["foo"])
+    with unittest.mock.patch(target="pace.driver.diagnostics.ZarrDiagnostics") as mock:
+        config.diagnostics_factory(unittest.mock.MagicMock(), unittest.mock.MagicMock())
+        mock.assert_called_once_with(
+            path=tmpdir,
+            names=["foo"],
+            partitioner=unittest.mock.ANY,
+            comm=unittest.mock.ANY,
+        )


### PR DESCRIPTION
## Purpose

Currently it is not possible to avoid creating a Zarr store with at least the grid diagnostics when running the model. However, using a zarr store makes it difficult to port cached communications between systems, as non-root ranks will crash if they receive a zarr group describing a store which does not exist.

This PR modifies the behavior of pace.driver.run so that if no path is given for the diagnostics (previously a path was required), no diagnostics will be stored.

## Code changes:

- DiagnosticsConfig's path argument is now optional, if not given then no diagnostics are stored.

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
