### PR TITLE
Fix/driver translate test on Jenkins

### DIFF
--- a/.jenkins/actions/run_driver_parallel_regression_tests.sh
+++ b/.jenkins/actions/run_driver_parallel_regression_tests.sh
@@ -5,7 +5,7 @@ BACKEND=$1
 export TEST_ARGS="-v -s -rsx --backend=${BACKEND} "
 
 if [ ${python_env} == "virtualenv" ]; then
-    CONTAINER_CMD="" make driver_savepoint_tests_mpi
+    CONTAINER_CMD="" TARGET=driver make driver_savepoint_tests_mpi
 else
-    make driver_savepoint_tests_mpi
+    TARGET=driver make driver_savepoint_tests_mpi
 fi

--- a/.jenkins/actions/run_driver_parallel_regression_tests.sh
+++ b/.jenkins/actions/run_driver_parallel_regression_tests.sh
@@ -5,7 +5,7 @@ BACKEND=$1
 export TEST_ARGS="-v -s -rsx --backend=${BACKEND} "
 
 if [ ${python_env} == "virtualenv" ]; then
-    CONTAINER_CMD="" TARGET=driver make driver_savepoint_tests_mpi
+    CONTAINER_CMD="" make driver_savepoint_tests_mpi
 else
-    TARGET=driver make driver_savepoint_tests_mpi
+    make driver_savepoint_tests_mpi
 fi

--- a/.jenkins/actions/run_physics_parallel_regression_tests.sh
+++ b/.jenkins/actions/run_physics_parallel_regression_tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e -x
 BACKEND=$1
-EXPNAME=$2
 export TEST_ARGS="-v -s -rsx --backend=${BACKEND} "
 
 if [ ${python_env} == "virtualenv" ]; then

--- a/.jenkins/actions/run_physics_regression_tests.sh
+++ b/.jenkins/actions/run_physics_regression_tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e -x
 BACKEND=$1
-EXPNAME=$2
 XML_REPORT="sequential_test_results.xml"
 export TEST_ARGS="-v -s -rsx --backend=${BACKEND} "
 

--- a/fv3gfs-physics/tests/savepoint/translate/translate_driver.py
+++ b/fv3gfs-physics/tests/savepoint/translate/translate_driver.py
@@ -1,5 +1,3 @@
-from mpi4py import MPI
-
 import pace.dsl
 import pace.util
 from fv3core._config import DynamicalCoreConfig
@@ -51,7 +49,7 @@ class TranslateDriver(TranslateFVDynamics):
             quantity_factory=quantity_factory,
         )
         config_info = {
-            "stencil_config": self.stencil_config.stencil_kwargs,
+            "stencil_config": self.stencil_config,
             "initialization_type": "predefined",
             "initialization_config": {
                 "dycore_state": dycore_state,
@@ -73,7 +71,7 @@ class TranslateDriver(TranslateFVDynamics):
             "layout": tuple(self.namelist.layout),
         }
         config = DriverConfig.from_dict(config_info)
-        driver = Driver(config=config, comm=MPI.COMM_WORLD)
+        driver = Driver(config=config)
 
         driver.step_all()
         self.dycore = driver.dycore


### PR DESCRIPTION
## Purpose

We enable running driver translate test as part of physics regression PR test plan. 

## Code changes:

- Add `target` to `run_driver_parallel_regression_tests.sh` because driver savepoints are in a separate bucket
- Remove `EXPNAME` in run physics scripts as it is not in use
- Minor change in `translate_driver` to the savepoint test to run properly

## Infrastructure changes:

- A new runaction is added in Jenkins pace-physics-regression_PR
  - translate driver currently only runs on `gtc:numpy`
  - will need to have a caching strategy for running performance backend

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
