### PR TITLE
pace-util: zarr monitor quantity attribute handling

### DIFF
--- a/pace-util/HISTORY.md
+++ b/pace-util/HISTORY.md
@@ -3,6 +3,7 @@ History
 
 latest
 ------
+- Changed `ZarrMonitor.store` behavior to transposing quantities without losing attributes, and loosening requirements on attribute consistency
 
 v0.8.0
 ------

--- a/pace-util/pace/util/quantity.py
+++ b/pace-util/pace/util/quantity.py
@@ -533,6 +533,13 @@ class Quantity:
         )
 
     def update_attrs(self, attrs: dict) -> None:
+        """Update the attributes of the quantity in place.
+
+        Note that `units` is not a mutable attribute and is set on creation
+
+        Args:
+            attrs: attributes to be updated
+        """
         self._attrs.update(attrs)
 
 

--- a/pace-util/pace/util/quantity.py
+++ b/pace-util/pace/util/quantity.py
@@ -532,6 +532,9 @@ class Quantity:
             gt4py_backend=self.gt4py_backend,
         )
 
+    def update_attrs(self, attrs: dict) -> None:
+        self._attrs.update(attrs)
+
 
 def transpose_sequence(sequence, order):
     return sequence.__class__(sequence[i] for i in order)

--- a/pace-util/pace/util/quantity.py
+++ b/pace-util/pace/util/quantity.py
@@ -523,7 +523,7 @@ class Quantity:
         """
         target_dims = _collapse_dims(target_dims, self.dims)
         transpose_order = [self.dims.index(dim) for dim in target_dims]
-        return Quantity(
+        transposed = Quantity(
             self.np.transpose(self.data, transpose_order),  # type: ignore[attr-defined]
             dims=transpose_sequence(self.dims, transpose_order),
             units=self.units,
@@ -531,16 +531,8 @@ class Quantity:
             extent=transpose_sequence(self.extent, transpose_order),
             gt4py_backend=self.gt4py_backend,
         )
-
-    def update_attrs(self, attrs: dict) -> None:
-        """Update the attributes of the quantity in place.
-
-        Note that `units` is not a mutable attribute and is set on creation
-
-        Args:
-            attrs: attributes to be updated
-        """
-        self._attrs.update(attrs)
+        transposed._attrs = self._attrs
+        return transposed
 
 
 def transpose_sequence(sequence, order):

--- a/pace-util/pace/util/zarr_monitor.py
+++ b/pace-util/pace/util/zarr_monitor.py
@@ -227,6 +227,7 @@ class _ZarrVariableWriter:
             self._init_zarr(quantity)
 
         quantity = self._match_dim_order(quantity)
+        self._check_units(quantity)
 
         if self.i_time >= self.array.shape[0] and self.rank == 0:
             new_shape = list(
@@ -235,7 +236,6 @@ class _ZarrVariableWriter:
             )
             new_shape[0] = self.i_time + 1
             self.array.resize(*new_shape)
-            self._ensure_compatible_attrs(quantity)
         self.sync_array()
 
         target_slice = (
@@ -285,12 +285,12 @@ class _ZarrVariableWriter:
         transposed.update_attrs(dissoc(quantity.attrs, "units"))
         return transposed
 
-    def _ensure_compatible_attrs(self, new_quantity):
-        new_attrs = self._get_attrs(new_quantity)
-        if dict(self.array.attrs) != new_attrs:
+    def _check_units(self, new_quantity):
+        units = self.array.attrs.get("units")
+        if units != new_quantity.units:
             raise ValueError(
-                f"value for {self.name} with attrs {new_attrs} "
-                f"does not match previously stored attrs {dict(self.array.attrs)}"
+                f"value for {self.name} with units {new_quantity.units} "
+                f"does not match previously stored units {units}"
             )
 
 

--- a/pace-util/tests/quantity/test_transpose.py
+++ b/pace-util/tests/quantity/test_transpose.py
@@ -202,3 +202,12 @@ def test_transpose_invalid_cases(
 ):
     with pytest.raises(ValueError):
         quantity.transpose(target_dims)
+
+
+def test_transpose_retains_attrs(numpy):
+    quantity = pace.util.Quantity(
+        numpy.random.randn(3, 4), dims=["x", "y"], units="unit_string"
+    )
+    quantity._attrs = {"long_name": "500 mb height"}
+    transposed = quantity.transpose(["y", "x"])
+    assert transposed.attrs == quantity.attrs

--- a/pace-util/tests/test_zarr_monitor.py
+++ b/pace-util/tests/test_zarr_monitor.py
@@ -490,18 +490,9 @@ def test_diags_fail_different_dim_set(diag, numpy, zarr_monitor_single_rank):
         dims=new_dims,
         units="m",
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         zarr_monitor_single_rank.store({"time": time_2, "a": diag_2})
-
-
-@requires_zarr
-def test_transposed_diags_retain_attrs(diag, zarr_monitor_single_rank):
-
-    zarr_monitor_single_rank.store({"a": diag})
-    diag_2 = copy.deepcopy(diag)
-    diag_2.update_attrs({"some_non_units_attr": 9.0})
-    transposed_diag = zarr_monitor_single_rank._writers["a"]._transpose(diag_2)
-    assert transposed_diag.attrs == diag_2.attrs
+    assert "Attempting to append a quantity" in str(excinfo.value)
 
 
 @requires_zarr
@@ -512,7 +503,7 @@ def test_diags_only_consistent_units_attrs_required(diag, zarr_monitor_single_ra
     time_3 = cftime.DatetimeJulian(2010, 6, 20, 6, 30, 0)
     zarr_monitor_single_rank.store({"time": time_1, "a": diag})
     diag_2 = copy.deepcopy(diag)
-    diag_2.update_attrs({"some_non_units_attrs": 9.0})
+    diag_2._attrs.update({"some_non_units_attrs": 9.0})
     zarr_monitor_single_rank.store({"time": time_2, "a": diag_2})
     diag_3 = pace.util.Quantity(data=diag.values, dims=diag.dims, units="not_m")
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Purpose

Allow the `pace.util.ZarrMonitor` to handle incoming diagnostic `pace.util.Quantity` objects with different dimension orders, without losing the attributes of those Quantities. Also relax the requirements of consistency in incoming zarr monitor Quantities' attributes, beyond consistent units and dimensions. Both of these changes are intended to make the fv3net integration of the zarr monitor more robust. 

## Code changes:

- `pace.util.ZarrMonitor` can now store incoming diagnostic `pace.util.Quantity` objects with different dimension orders and inconsistent attributes (except for units and the set of dimensions, which must be consistent). 

## Checklist
Before submitting this PR, please make sure:

- [X] Docstrings and type hints are added to new and updated routines, as appropriate
- [X] For each public change and fix in `pace-util`, HISTORY has been updated
- [X] Unit tests are added or updated for non-stencil code changes
