### PR TITLE
Fix Overrides

### DIFF
--- a/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/fv3core/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -1,6 +1,5 @@
 C_SW:
-  - backend: numpy
-    max_error: 5e-2
+  - max_error: 5e-2
 
 FVDynamics:
   - ignore_near_zero_errors:
@@ -12,8 +11,7 @@ FVDynamics:
       cyd: 1e-3
 
 DynCore:
-  - backend: numpy
-    ignore_near_zero_errors:
+  - ignore_near_zero_errors:
       uc: 1e-13
       vc: 1e-13
       mfxd: 1e-3
@@ -22,16 +20,14 @@ DynCore:
       cyd: 1e-3
 
 D_SW:
-  - backend: numpy
-    ignore_near_zero_errors:
+  - ignore_near_zero_errors:
       divgdd: 1e-20
       ucd: 1e-20
       vcd: 1e-20
       delpcd: 1e-15
 
 DivergenceDamping:
-  - backend: numpy
-    ignore_near_zero_errors:
+  - ignore_near_zero_errors:
       vort: 6e-8
       delpc: 1e-15
 

--- a/fv3core/tests/savepoint/translate/overrides/standard.yaml
+++ b/fv3core/tests/savepoint/translate/overrides/standard.yaml
@@ -33,7 +33,7 @@ MapN_Tracer_2d:
     near_zero: 1e-17
     ignore_near_zero_errors:
       - qtracers
-  - backend: numpy
+  - backend: gtc:numpy
     max_error: 9e-9 # 48_6ranks
 
 
@@ -51,7 +51,7 @@ Riem_Solver3:
   - backend: gtc:cuda
     max_error: 5e-6
   - platform: metal
-    backend: numpy
+    backend: gtc:numpy
     max_error: 1e-11 # 48_6ranks
 
 Remapping:


### PR DESCRIPTION
fix test overrides files that refer to the numpy backend, when it should be gtc:numpy, or not specified (because if it is needed for gtc:numpy, it almost certainly is needed for the other backends)

