### PR TITLE
consolidate imports of mpi4py into pace.util, remove fv3core null_comm

### DIFF
--- a/driver/examples/stencil_signatures.py
+++ b/driver/examples/stencil_signatures.py
@@ -4,7 +4,6 @@ from typing import Optional, TextIO
 
 import yaml
 
-import fv3core.utils.null_comm
 import pace.driver
 import pace.dsl
 import pace.util
@@ -56,7 +55,7 @@ if __name__ == "__main__":
         driver_config = pace.driver.DriverConfig.from_dict(yaml.safe_load(f))
     driver = pace.driver.Driver(
         config=driver_config,
-        comm=fv3core.utils.null_comm.NullComm(rank=0, total_ranks=6),
+        comm=pace.util.null_comm.NullComm(rank=0, total_ranks=6),
     )
     with open("stencil_report.txt", "w") as f:
         report_stencils(driver.dycore, file=f)

--- a/driver/tests/test_driver.py
+++ b/driver/tests/test_driver.py
@@ -8,7 +8,6 @@ from typing import Literal, Tuple
 import pytest
 
 import pace.dsl
-from fv3core.utils.null_comm import NullComm
 from pace.driver import CreatesComm, Driver, DriverConfig
 from pace.driver.report import (
     TimeReport,
@@ -16,6 +15,7 @@ from pace.driver.report import (
     gather_timing_data,
     get_sypd,
 )
+from pace.util.null_comm import NullComm
 
 
 def get_driver_config(

--- a/dsl/pace/dsl/future_stencil.py
+++ b/dsl/pace/dsl/future_stencil.py
@@ -7,11 +7,7 @@ from gt4py.definitions import FieldInfo
 from gt4py.stencil_builder import StencilBuilder
 from gt4py.stencil_object import StencilObject
 
-
-try:
-    from mpi4py import MPI
-except ImportError:
-    MPI = None
+from pace.util.mpi import MPI
 
 
 class Singleton(type):

--- a/dsl/pace/dsl/stencil.py
+++ b/dsl/pace/dsl/stencil.py
@@ -31,12 +31,7 @@ import pace.util
 from pace.dsl.typing import Index3D, cast_to_index3d
 from pace.util import testing
 from pace.util.halo_data_transformer import QuantityHaloSpec
-
-
-try:
-    from mpi4py import MPI
-except ImportError:
-    MPI = None
+from pace.util.mpi import MPI
 
 
 @dataclasses.dataclass

--- a/fv3core/examples/standalone/runfile/acoustics.py
+++ b/fv3core/examples/standalone/runfile/acoustics.py
@@ -13,8 +13,8 @@ import pace.util as util
 from fv3core._config import DynamicalCoreConfig
 from fv3core.stencils.dyn_core import AcousticDynamics
 from fv3core.testing import TranslateDynCore
-from fv3core.utils.null_comm import NullComm
 from pace.stencils.testing.grid import Grid
+from pace.util.null_comm import NullComm
 
 
 try:

--- a/fv3core/examples/standalone/runfile/compile.py
+++ b/fv3core/examples/standalone/runfile/compile.py
@@ -7,7 +7,7 @@ import f90nml
 
 import pace.dsl.stencil  # noqa: F401
 from fv3core._config import DynamicalCoreConfig
-from fv3core.utils.null_comm import NullComm
+from pace.util.null_comm import NullComm
 
 
 local = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/fv3core/examples/standalone/runfile/dynamics.py
+++ b/fv3core/examples/standalone/runfile/dynamics.py
@@ -21,9 +21,9 @@ from fv3core import DynamicalCore
 from fv3core._config import DynamicalCoreConfig
 from fv3core.initialization.baroclinic import init_baroclinic_state
 from fv3core.testing import TranslateFVDynamics
-from fv3core.utils.null_comm import NullComm
 from pace.stencils.testing.grid import Grid
 from pace.util.grid import DampingCoefficients, GridData, MetricTerms
+from pace.util.null_comm import NullComm
 
 
 def parse_args() -> Namespace:

--- a/fv3core/fv3core/utils/mpi.py
+++ b/fv3core/fv3core/utils/mpi.py
@@ -1,4 +1,0 @@
-try:
-    from mpi4py import MPI
-except ImportError:
-    MPI = None

--- a/fv3core/fv3core/utils/null_comm.py
+++ b/fv3core/fv3core/utils/null_comm.py
@@ -1,6 +1,0 @@
-from pace.util import NullComm  # noqa: F401
-from pace.util.null_comm import NullAsyncResult  # noqa: F401
-
-
-# this file exists for namespacing backwards compatibility
-# feel free to refactor it away

--- a/fv3core/tests/main/dsl/test_future_stencil.py
+++ b/fv3core/tests/main/dsl/test_future_stencil.py
@@ -7,11 +7,11 @@ import pytest
 from gt4py.gtscript import PARALLEL, computation, interval
 from gt4py.stencil_object import StencilObject
 
-from fv3core.utils.mpi import MPI
 from pace.dsl.future_stencil import FutureStencil, StencilTable, future_stencil
 from pace.dsl.gt4py_utils import make_storage_from_shape
 from pace.dsl.typing import FloatField, IntField
 from pace.util.global_config import set_backend
+from pace.util.mpi import MPI
 
 
 def copy_stencil(q_in: FloatField, q_out: FloatField):

--- a/fv3core/tests/main/test_dycore_call.py
+++ b/fv3core/tests/main/test_dycore_call.py
@@ -9,8 +9,8 @@ import fv3core.initialization.baroclinic as baroclinic_init
 import pace.dsl.stencil
 import pace.stencils.testing
 import pace.util
-from fv3core.utils.null_comm import NullComm
 from pace.util.grid import DampingCoefficients, GridData, MetricTerms
+from pace.util.null_comm import NullComm
 
 
 DIR = os.path.abspath(os.path.dirname(__file__))

--- a/fv3core/tests/savepoint/conftest.py
+++ b/fv3core/tests/savepoint/conftest.py
@@ -13,8 +13,8 @@ import fv3core._config
 import pace.dsl
 import pace.util as fv3util
 from fv3core import DynamicalCoreConfig
-from fv3core.utils.mpi import MPI
 from pace.stencils.testing import ParallelTranslate, TranslateGrid
+from pace.util.mpi import MPI
 
 from . import translate
 

--- a/fv3core/tests/savepoint/test_translate.py
+++ b/fv3core/tests/savepoint/test_translate.py
@@ -9,7 +9,7 @@ import serialbox as ser
 
 import pace.dsl.gt4py_utils as gt_utils
 import pace.util as fv3util
-from fv3core.utils.mpi import MPI
+from pace.util.mpi import MPI
 from pace.util.testing import compare_scalar, success, success_array
 
 

--- a/pace-util/tests/test_null_comm.py
+++ b/pace-util/tests/test_null_comm.py
@@ -1,5 +1,5 @@
 import pace.util
-from fv3core.utils.null_comm import NullComm
+from pace.util.null_comm import NullComm
 
 
 def test_can_create_cube_communicator():


### PR DESCRIPTION
## Purpose

This PR replaces mpi4py.MPI imports with imports from pace.util.mpi, and replaces references to fv3core.utils.null_comm with references to pace.util.null_comm.

## Code changes:

- replaced mpi4py.MPI imports with imports from pace.util.mpi
- replaced references to fv3core.utils.null_comm with references to pace.util.null_comm

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
