### PR TITLE
Refactor optional dependencies, make zarr optional in pace.driver

### DIFF
--- a/driver/pace/driver/report.py
+++ b/driver/pace/driver/report.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List
 
 import numpy as np
 
-from .comm import Comm
+from pace.util.comm import Comm
 
 
 @dataclasses.dataclass

--- a/driver/pace/driver/report.py
+++ b/driver/pace/driver/report.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List
 
 import numpy as np
 
-from pace.util.mpi import MPI
+from .comm import Comm
 
 
 @dataclasses.dataclass
@@ -121,7 +121,7 @@ def collect_data_and_write_to_file(
     time_step: int,
     backend: str,
     git_hash: str,
-    comm: MPI.Comm,
+    comm: Comm,
     hits_per_step: List,
     times_per_step: List,
     experiment_name: str,

--- a/pace-util/pace/util/_optional_imports.py
+++ b/pace-util/pace/util/_optional_imports.py
@@ -7,3 +7,19 @@ class RaiseWhenAccessed:
 
     def __call__(self, *args, **kwargs):
         raise self._err
+
+
+try:
+    import zarr
+except ModuleNotFoundError as err:
+    zarr = RaiseWhenAccessed(err)
+
+try:
+    import cupy
+except ImportError:
+    cupy = None
+
+try:
+    import gt4py
+except ImportError:
+    gt4py = None

--- a/pace-util/pace/util/cuda_kernels.py
+++ b/pace-util/pace/util/cuda_kernels.py
@@ -1,9 +1,5 @@
 # flake8: noqa
-
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
+from ._optional_imports import cupy as cp
 
 
 pack_scalar_f64_kernel = (

--- a/pace-util/pace/util/halo_data_transformer.py
+++ b/pace-util/pace/util/halo_data_transformer.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid1
 
 import numpy as np
 
+from ._optional_imports import cupy as cp
 from .buffer import Buffer
 from .cuda_kernels import (
     pack_scalar_f64_kernel,
@@ -17,12 +18,6 @@ from .quantity import Quantity
 from .rotate import rotate_scalar_data, rotate_vector_data
 from .types import NumpyModule
 from .utils import device_synchronize
-
-
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
 
 
 @dataclass

--- a/pace-util/pace/util/initialization/allocator.py
+++ b/pace-util/pace/util/initialization/allocator.py
@@ -1,14 +1,9 @@
 from typing import Callable, Sequence
 
+from .._optional_imports import gt4py
 from ..constants import SPATIAL_DIMS, X_DIMS, Y_DIMS, Z_DIMS
 from ..quantity import Quantity
 from .sizer import GridSizer
-
-
-try:
-    import gt4py
-except ImportError:
-    gt4py = None
 
 
 def _wrap_storage_call(function, backend):

--- a/pace-util/pace/util/quantity.py
+++ b/pace-util/pace/util/quantity.py
@@ -6,17 +6,12 @@ import numpy as np
 
 from . import _xarray, constants
 from ._boundary_utils import bound_default_slice, shift_boundary_slice_tuple
+from ._optional_imports import cupy, gt4py
 from .types import NumpyModule
 
 
-try:
-    import cupy
-except ImportError:
-    cupy = np  # avoids attribute errors while also disabling cupy support
-try:
-    import gt4py
-except ImportError:
-    gt4py = None
+if cupy is None:
+    import numpy as cupy
 
 __all__ = ["Quantity", "QuantityMetadata"]
 

--- a/pace-util/pace/util/utils.py
+++ b/pace-util/pace/util/utils.py
@@ -3,17 +3,13 @@ from typing import Iterable, Sequence, Tuple, TypeVar, Union
 import numpy as np
 
 from . import constants
+from ._optional_imports import cupy as cp
 from .types import Allocator
 
 
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
-
 # Run a deviceSynchronize() to check
 # that the GPU is present and ready to run
-if cp:
+if cp is not None:
     try:
         cp.cuda.runtime.deviceSynchronize()
         GPU_AVAILABLE = True

--- a/pace-util/pace/util/zarr_monitor.py
+++ b/pace-util/pace/util/zarr_monitor.py
@@ -4,24 +4,11 @@ from typing import List, Tuple, Union
 
 import cftime
 
-
-try:
-    import zarr
-except ModuleNotFoundError as err:
-    from ._optional_imports import RaiseWhenAccessed
-
-    zarr = RaiseWhenAccessed(err)
-import numpy as np
-
 from . import _xarray as xr
 from . import constants, utils
+from ._optional_imports import cupy, zarr
 from .partitioner import CubedSpherePartitioner, subtile_slice
 
-
-try:
-    import cupy
-except ImportError:
-    cupy = np
 
 logger = logging.getLogger("pace.util")
 


### PR DESCRIPTION
## Code changes:

- pace.driver will no longer raise on import if zarr is not installed
- reduce duplication of code handling for optional imports in pace.driver and pace.util

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
