### PR TITLE
Add NullCheckpointer called for C_SW and D_SW

### DIFF
--- a/fv3core/fv3core/stencils/dyn_core.py
+++ b/fv3core/fv3core/stencils/dyn_core.py
@@ -341,6 +341,9 @@ class AcousticDynamics:
             config: configuration settings
             pfull: atmospheric Eulerian grid reference pressure (Pa)
             phis: surface geopotential height
+            checkpointer: if given, used to perform operations on model data
+                at specific points in model execution, such as testing against
+                reference data
         """
         self.call_checkpointer = checkpointer is not None
         self.checkpointer = checkpointer

--- a/fv3core/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/fv3core/stencils/fv_dynamics.py
@@ -355,7 +355,7 @@ class DynamicalCore:
     def _checkpoint_fvdynamics(self, state: DycoreState, tag: str):
         if self.call_checkpointer:
             self.checkpointer(
-                "FVDynamics-" + tag,
+                f"FVDynamics-{tag}",
                 u=state.u,
                 v=state.v,
                 w=state.w,

--- a/fv3core/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/fv3core/stencils/fv_dynamics.py
@@ -352,6 +352,21 @@ class DynamicalCore:
         )
         self._omega_halo_updater = self.comm.get_scalar_halo_updater([full_xyz_spec])
 
+    def _checkpoint_fvdynamics(self, state: DycoreState, tag: str):
+        if self.call_checkpointer:
+            self.checkpointer(
+                "FVDynamics-" + tag,
+                u=state.u,
+                v=state.v,
+                w=state.w,
+                delz=state.delz,
+                ua=state.ua,
+                va=state.va,
+                uc=state.uc,
+                vc=state.vc,
+                qvapor=state.qvapor,
+            )
+
     def step_dynamics(
         self,
         state: DycoreState,
@@ -373,19 +388,7 @@ class DynamicalCore:
             n_split: number of acoustic timesteps per remapping timestep
             timer: if given, use for timing model execution
         """
-        if self.call_checkpointer:
-            self.checkpointer(
-                "FVDynamics-In",
-                u=state.u,
-                v=state.v,
-                w=state.w,
-                delz=state.delz,
-                ua=state.ua,
-                va=state.va,
-                uc=state.uc,
-                vc=state.vc,
-                qvapor=state.qvapor,
-            )
+        self._checkpoint_fvdynamics(state=state, tag="In")
         # TODO: state should be a statically typed class, move these to the
         # definition of DycoreState and pass them on init or alternatively
         # move these to/get these from the namelist/configuration class
@@ -400,19 +403,7 @@ class DynamicalCore:
             }
         )
         self._compute(state, timer)
-        if self.call_checkpointer:
-            self.checkpointer(
-                "FVDynamics-Out",
-                u=state.u,
-                v=state.v,
-                w=state.w,
-                delz=state.delz,
-                ua=state.ua,
-                va=state.va,
-                uc=state.uc,
-                vc=state.vc,
-                qvapor=state.qvapor,
-            )
+        self._checkpoint_fvdynamics(state=state, tag="Out")
 
     # TODO: type hint state when it is possible to do so, when it is a static type
     def _compute(

--- a/fv3core/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/fv3core/stencils/fv_dynamics.py
@@ -222,6 +222,9 @@ class DynamicalCore:
             config: configuration of dynamical core, for example as would be set by
                 the namelist in the Fortran model
             phis: surface geopotential height
+            checkpointer: if given, used to perform operations on model data
+                at specific points in model execution, such as testing against
+                reference data
         """
         # nested and stretched_grid are options in the Fortran code which we
         # have not implemented, so they are hard-coded here.

--- a/pace-util/HISTORY.md
+++ b/pace-util/HISTORY.md
@@ -7,6 +7,9 @@ latest
 v0.9.0
 ------
 
+Major changes:
+- Added Checkpointer and NullCheckpointer classes
+
 Minor changes:
 - Modified `pace.util.Quantity.transpose` to retain attributes, and loosened `pace.util.ZarrMonitor.store` requirements on attribute consistency, both to ease fv3net integration issues not addressed in v0.8.0
 

--- a/pace-util/pace/util/__init__.py
+++ b/pace-util/pace/util/__init__.py
@@ -7,6 +7,7 @@ from ._timing import NullTimer, Timer
 from ._xarray import to_dataset
 from .buffer import Buffer, array_buffer, recv_buffer, send_buffer
 from .caching_comm import CachingCommData, CachingCommReader, CachingCommWriter
+from .checkpointer import Checkpointer, NullCheckpointer
 from .communicator import Communicator, CubedSphereCommunicator, TileCommunicator
 from .constants import (
     BOUNDARY_TYPES,

--- a/pace-util/pace/util/checkpointer/__init__.py
+++ b/pace-util/pace/util/checkpointer/__init__.py
@@ -1,0 +1,2 @@
+from .base import Checkpointer
+from .null import NullCheckpointer

--- a/pace-util/pace/util/checkpointer/base.py
+++ b/pace-util/pace/util/checkpointer/base.py
@@ -1,0 +1,7 @@
+import abc
+
+
+class Checkpointer(abc.ABC):
+    @abc.abstractmethod
+    def __call__(self, savepoint_name, **kwargs):
+        ...

--- a/pace-util/pace/util/checkpointer/null.py
+++ b/pace-util/pace/util/checkpointer/null.py
@@ -1,0 +1,6 @@
+from .base import Checkpointer
+
+
+class NullCheckpointer(Checkpointer):
+    def __call__(self, savepoint_name, **kwargs):
+        pass


### PR DESCRIPTION
## Purpose

We are adding a checkpointer system to be able to test multiple savepoints in a single execution. This PR adds an abstract base class with a "no code" implementation so we can start adding calls to the checkpointer within our code.

## Code changes:

- Added Checkpointer and NullCheckpointer classes to pace-util
- Added `checkpointer` as arguments to AcousticDynamics and DynamicalCore, with a default NullCheckpointer value

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes