### PR TITLE
Revert serialbox init 

### DIFF
--- a/driver/pace/driver/initialization.py
+++ b/driver/pace/driver/initialization.py
@@ -3,6 +3,8 @@ import dataclasses
 from datetime import datetime
 from typing import ClassVar
 
+import f90nml
+
 import fv3core
 import fv3core.initialization.baroclinic as baroclinic_init
 import fv3gfs.physics
@@ -11,7 +13,11 @@ import pace.dsl
 import pace.stencils
 import pace.util
 import pace.util.grid
+from fv3core.testing import TranslateFVDynamics
+from pace.dsl.stencil import StencilFactory
+from pace.stencils.testing import TranslateGrid
 from pace.util.grid import DampingCoefficients
+from pace.util.namelist import Namelist
 
 from .registry import Registry
 from .state import DriverState, TendencyState, _restart_driver_state
@@ -134,6 +140,137 @@ class RestartConfig(Initializer):
             self.path, communicator.rank, quantity_factory, communicator
         )
         return state
+
+
+@InitializerSelector.register("serialbox")
+@dataclasses.dataclass
+class SerialboxConfig(Initializer):
+    """
+    Configuration for Serialbox initialization.
+    """
+
+    path: str
+    serialized_grid: bool
+
+    @property
+    def start_time(self) -> datetime:
+        return datetime(2000, 1, 1)
+
+    @property
+    def _f90_namelist(self) -> f90nml.Namelist:
+        return f90nml.read(self.path + "/input.nml")
+
+    @property
+    def _namelist(self) -> Namelist:
+        return Namelist.from_f90nml(self._f90_namelist)
+
+    def _get_serialized_grid(
+        self,
+        communicator: pace.util.CubedSphereCommunicator,
+        backend: str,
+    ) -> pace.stencils.testing.grid.Grid:
+        ser = self._serializer(communicator)
+        grid = TranslateGrid.new_from_serialized_data(
+            ser, communicator.rank, self._namelist.layout, backend
+        ).python_grid()
+        return grid
+
+    def _serializer(self, communicator: pace.util.CubedSphereCommunicator):
+        import serialbox
+
+        serializer = serialbox.Serializer(
+            serialbox.OpenModeKind.Read,
+            self.path,
+            "Generator_rank" + str(communicator.rank),
+        )
+        return serializer
+
+    def _get_grid_data_damping_coeff_and_driver_grid(
+        self,
+        quantity_factory: pace.util.QuantityFactory,
+        communicator: pace.util.CubedSphereCommunicator,
+        backend: str,
+    ):
+        if self.serialized_grid:
+            grid = self._get_serialized_grid(communicator, backend)
+            grid_data = grid.grid_data
+            driver_grid_data = grid.driver_grid_data
+            damping_coeff = grid.damping_coefficients
+        else:
+            grid = pace.stencils.testing.grid.Grid.with_data_from_namelist(
+                self._namelist, communicator, backend
+            )
+            metric_terms = pace.util.grid.MetricTerms(
+                quantity_factory=quantity_factory, communicator=communicator
+            )
+            grid_data = pace.util.grid.GridData.new_from_metric_terms(metric_terms)
+            damping_coeff = DampingCoefficients.new_from_metric_terms(metric_terms)
+            driver_grid_data = pace.util.grid.DriverGridData.new_from_metric_terms(
+                metric_terms
+            )
+        return grid, grid_data, damping_coeff, driver_grid_data
+
+    def get_driver_state(
+        self,
+        quantity_factory: pace.util.QuantityFactory,
+        communicator: pace.util.CubedSphereCommunicator,
+    ) -> DriverState:
+        backend = quantity_factory.empty(
+            dims=[pace.util.X_DIM, pace.util.Y_DIM], units="unknown"
+        ).gt4py_backend
+        (
+            grid,
+            grid_data,
+            damping_coeff,
+            driver_grid_data,
+        ) = self._get_grid_data_damping_coeff_and_driver_grid(
+            quantity_factory, communicator, backend
+        )
+        dycore_state = self._initialize_dycore_state(
+            quantity_factory, communicator, backend
+        )
+        physics_state = fv3gfs.physics.PhysicsState.init_zeros(
+            quantity_factory=quantity_factory,
+            active_packages=["microphysics"],
+        )
+        tendency_state = TendencyState.init_zeros(
+            quantity_factory=quantity_factory,
+        )
+        return DriverState(
+            dycore_state=dycore_state,
+            physics_state=physics_state,
+            tendency_state=tendency_state,
+            grid_data=grid_data,
+            damping_coefficients=damping_coeff,
+            driver_grid_data=driver_grid_data,
+        )
+
+    def _initialize_dycore_state(
+        self,
+        quantity_factory: pace.util.QuantityFactory,
+        communicator: pace.util.CubedSphereCommunicator,
+        backend: str,
+    ) -> fv3core.DycoreState:
+        (
+            grid,
+            grid_data,
+            damping_coeff,
+            driver_grid_data,
+        ) = self._get_grid_data_damping_coeff_and_driver_grid(
+            quantity_factory, communicator, backend
+        )
+        ser = self._serializer(communicator)
+        savepoint_in = ser.get_savepoint("Driver-In")[0]
+        stencil_config = pace.dsl.stencil.StencilConfig(
+            backend=backend,
+        )
+        stencil_factory = StencilFactory(
+            config=stencil_config, grid_indexing=grid.grid_indexing
+        )
+        translate_object = TranslateFVDynamics([grid], self._namelist, stencil_factory)
+        input_data = translate_object.collect_input_data(ser, savepoint_in)
+        dycore_state = translate_object.state_from_inputs(input_data)
+        return dycore_state
 
 
 @InitializerSelector.register("predefined")


### PR DESCRIPTION
## Purpose

We revert the capability of initializing from serialbox.

## Code changes:

- `SerialboxConfig` is now an option in initialization 

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
