### PR TITLE
Zero heat_source temporary between dycore calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ There is no determined convention for order of arguments, but the code generally
 
 Another example
 ```python
-def make_storage_from_shape(shape, origin, dtype, init=True):
+def make_storage_from_shape(shape, origin, dtype):
 ```
 
 Turns into
@@ -105,7 +105,6 @@ Turns into
         origin: Tuple[int, int, int],
         *,
         dtype: DTypes = np.float64,
-        init: bool = True,
     ) -> Field:
 ```
 

--- a/dsl/pace/dsl/gt4py_utils.py
+++ b/dsl/pace/dsl/gt4py_utils.py
@@ -235,16 +235,14 @@ def make_storage_from_shape(
     *,
     backend: str,
     dtype: DTypes = np.float64,
-    init: bool = False,
     mask: Optional[Tuple[bool, bool, bool]] = None,
 ) -> Field:
-    """Create a new gt4py storage of a given shape.
+    """Create a new gt4py storage of a given shape filled with zeros.
 
     Args:
         shape: Shape of the new storage
         origin: Default origin for gt4py stencil calls
         dtype: Data type
-        init: If True, initializes the storage to zero
         mask: Tuple indicating the axes used when initializing the storage
         backend: gt4py backend to use when making the storage
 
@@ -266,7 +264,6 @@ def make_storage_from_shape(
             mask = (n_dims * (True,)) + ((3 - n_dims) * (False,))
     # NOTE (jdahm): Temporary until Jenkins is updated
     backend = backend.replace("gtc:", "")
-    # storage_func = gt_storage.zeros if init else gt_storage.empty
     storage = gt_storage.zeros(
         backend=backend,
         default_origin=origin,

--- a/dsl/pace/dsl/gt4py_utils.py
+++ b/dsl/pace/dsl/gt4py_utils.py
@@ -238,7 +238,7 @@ def make_storage_from_shape(
     init: bool = False,
     mask: Optional[Tuple[bool, bool, bool]] = None,
 ) -> Field:
-    """Create a new gt4py storage of a given shape. Do not memoize outputs.
+    """Create a new gt4py storage of a given shape.
 
     Args:
         shape: Shape of the new storage
@@ -266,8 +266,8 @@ def make_storage_from_shape(
             mask = (n_dims * (True,)) + ((3 - n_dims) * (False,))
     # NOTE (jdahm): Temporary until Jenkins is updated
     backend = backend.replace("gtc:", "")
-    storage_func = gt_storage.zeros if init else gt_storage.empty
-    storage = storage_func(
+    # storage_func = gt_storage.zeros if init else gt_storage.empty
+    storage = gt_storage.zeros(
         backend=backend,
         default_origin=origin,
         shape=shape,

--- a/dsl/pace/dsl/gt4py_utils.py
+++ b/dsl/pace/dsl/gt4py_utils.py
@@ -254,7 +254,7 @@ def make_storage_from_shape(
         2) qx = utils.make_storage_from_shape(
                qin.shape, origin=(grid().is_, grid().jsd, kstart)
            )
-        3) q_out = utils.make_storage_from_shape(q_in.shape, origin, init=True)
+        3) q_out = utils.make_storage_from_shape(q_in.shape, origin,)
     """
     if not mask:
         n_dims = len(shape)
@@ -303,32 +303,9 @@ def make_storage_dict(
     return data_dict
 
 
-# def k_slice_operation(key, value, ki, dictionary):
-#     if isinstance(value, gt_storage.storage.Storage):
-#         shape = value.shape
-#         mask = dictionary[key].mask if key in dictionary else (True, True, True)
-#         if len(shape) == 1:  # K-field
-#             if mask[2]:
-#                 shape = (1, 1, len(ki))
-#                 dictionary[key] = make_storage_data(value[ki], shape, read_only=True)
-#         elif len(shape) == 2:  # IK-field
-#             if not mask[1]:
-#                 dictionary[key] = make_storage_data(
-#                     value[:, ki], (shape[0], 1, len(ki)), read_only=True
-#                 )
-#         else:  # IJK-field
-#             dictionary[key] = make_storage_data(
-#                 value[:, :, ki], (shape[0], shape[1], len(ki)), read_only=True
-#             )
-#     else:
-#         dictionary[key] = value
-
-
 def storage_dict(st_dict, names, shape, origin, *, backend: str):
     for name in names:
-        st_dict[name] = make_storage_from_shape(
-            shape, origin, init=True, backend=backend
-        )
+        st_dict[name] = make_storage_from_shape(shape, origin, backend=backend)
 
 
 def get_kstarts(column_info, npz):

--- a/fv3core/fv3core/initialization/baroclinic.py
+++ b/fv3core/fv3core/initialization/baroclinic.py
@@ -439,7 +439,7 @@ def init_baroclinic_state(
     hydrostatic: bool,
     moist_phys: bool,
     comm: fv3util.CubedSphereCommunicator,
-):
+) -> DycoreState:
     """
     Create a DycoreState object with quantities initialized to the Jablonowski &
     Williamson baroclinic test case perturbation applied to the cubed sphere grid.

--- a/fv3core/fv3core/initialization/dycore_state.py
+++ b/fv3core/fv3core/initialization/dycore_state.py
@@ -3,275 +3,275 @@ from typing import Any, Mapping
 
 import xarray as xr
 
-from pace import util
+import pace.util
 
 
 @dataclass()
 class DycoreState:
-    u: util.Quantity = field(
+    u: pace.util.Quantity = field(
         metadata={
             "name": "x_wind",
-            "dims": [util.X_DIM, util.Y_INTERFACE_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM, pace.util.Z_DIM],
             "units": "m/s",
             "intent": "inout",
         }
     )
-    v: util.Quantity = field(
+    v: pace.util.Quantity = field(
         metadata={
             "name": "y_wind",
-            "dims": [util.X_INTERFACE_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
             "intent": "inout",
         }
     )
-    w: util.Quantity = field(
+    w: pace.util.Quantity = field(
         metadata={
             "name": "vertical_wind",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
             "intent": "inout",
         }
     )
-    ua: util.Quantity = field(
+    ua: pace.util.Quantity = field(
         metadata={
             "name": "eastward_wind",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
             "intent": "inout",
         }
     )
-    va: util.Quantity = field(
+    va: pace.util.Quantity = field(
         metadata={
             "name": "northward_wind",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
         }
     )
-    uc: util.Quantity = field(
+    uc: pace.util.Quantity = field(
         metadata={
             "name": "x_wind_on_c_grid",
-            "dims": [util.X_INTERFACE_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
             "intent": "inout",
         }
     )
-    vc: util.Quantity = field(
+    vc: pace.util.Quantity = field(
         metadata={
             "name": "y_wind_on_c_grid",
-            "dims": [util.X_DIM, util.Y_INTERFACE_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM, pace.util.Z_DIM],
             "units": "m/s",
             "intent": "inout",
         }
     )
-    delp: util.Quantity = field(
+    delp: pace.util.Quantity = field(
         metadata={
             "name": "pressure_thickness_of_atmospheric_layer",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "Pa",
             "intent": "inout",
         }
     )
-    delz: util.Quantity = field(
+    delz: pace.util.Quantity = field(
         metadata={
             "name": "vertical_thickness_of_atmospheric_layer",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m",
             "intent": "inout",
         }
     )
-    ps: util.Quantity = field(
+    ps: pace.util.Quantity = field(
         metadata={
             "name": "surface_pressure",
-            "dims": [util.X_DIM, util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "Pa",
             "intent": "inout",
         }
     )
-    pe: util.Quantity = field(
+    pe: pace.util.Quantity = field(
         metadata={
             "name": "interface_pressure",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_INTERFACE_DIM],
             "units": "Pa",
             "n_halo": 1,
             "intent": "inout",
         }
     )
-    pt: util.Quantity = field(
+    pt: pace.util.Quantity = field(
         metadata={
             "name": "air_temperature",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "degK",
             "intent": "inout",
         }
     )
-    peln: util.Quantity = field(
+    peln: pace.util.Quantity = field(
         metadata={
             "name": "logarithm_of_interface_pressure",
             "dims": [
-                util.X_DIM,
-                util.Y_DIM,
-                util.Z_INTERFACE_DIM,
+                pace.util.X_DIM,
+                pace.util.Y_DIM,
+                pace.util.Z_INTERFACE_DIM,
             ],
             "units": "ln(Pa)",
             "n_halo": 0,
             "intent": "inout",
         }
     )
-    pk: util.Quantity = field(
+    pk: pace.util.Quantity = field(
         metadata={
             "name": "interface_pressure_raised_to_power_of_kappa",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_INTERFACE_DIM],
             "units": "unknown",
             "n_halo": 0,
             "intent": "inout",
         }
     )
-    pkz: util.Quantity = field(
+    pkz: pace.util.Quantity = field(
         metadata={
             "name": "layer_mean_pressure_raised_to_power_of_kappa",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "unknown",
             "n_halo": 0,
             "intent": "inout",
         }
     )
-    qvapor: util.Quantity = field(
+    qvapor: pace.util.Quantity = field(
         metadata={
             "name": "specific_humidity",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
         }
     )
-    qliquid: util.Quantity = field(
+    qliquid: pace.util.Quantity = field(
         metadata={
             "name": "cloud_water_mixing_ratio",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
     )
-    qice: util.Quantity = field(
+    qice: pace.util.Quantity = field(
         metadata={
             "name": "cloud_ice_mixing_ratio",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
     )
-    qrain: util.Quantity = field(
+    qrain: pace.util.Quantity = field(
         metadata={
             "name": "rain_mixing_ratio",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
     )
-    qsnow: util.Quantity = field(
+    qsnow: pace.util.Quantity = field(
         metadata={
             "name": "snow_mixing_ratio",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
     )
-    qgraupel: util.Quantity = field(
+    qgraupel: pace.util.Quantity = field(
         metadata={
             "name": "graupel_mixing_ratio",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
     )
-    qo3mr: util.Quantity = field(
+    qo3mr: pace.util.Quantity = field(
         metadata={
             "name": "ozone_mixing_ratio",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
     )
-    qsgs_tke: util.Quantity = field(
+    qsgs_tke: pace.util.Quantity = field(
         metadata={
             "name": "turbulent_kinetic_energy",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m**2/s**2",
             "intent": "inout",
         }
     )
-    qcld: util.Quantity = field(
+    qcld: pace.util.Quantity = field(
         metadata={
             "name": "cloud_fraction",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "",
             "intent": "inout",
         }
     )
-    q_con: util.Quantity = field(
+    q_con: pace.util.Quantity = field(
         metadata={
             "name": "total_condensate_mixing_ratio",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
     )
-    omga: util.Quantity = field(
+    omga: pace.util.Quantity = field(
         metadata={
             "name": "vertical_pressure_velocity",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "Pa/s",
             "intent": "inout",
         }
     )
-    mfxd: util.Quantity = field(
+    mfxd: pace.util.Quantity = field(
         metadata={
             "name": "accumulated_x_mass_flux",
-            "dims": [util.X_INTERFACE_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "unknown",
             "n_halo": 0,
             "intent": "inout",
         }
     )
-    mfyd: util.Quantity = field(
+    mfyd: pace.util.Quantity = field(
         metadata={
             "name": "accumulated_y_mass_flux",
-            "dims": [util.X_DIM, util.Y_INTERFACE_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM, pace.util.Z_DIM],
             "units": "unknown",
             "n_halo": 0,
             "intent": "inout",
         }
     )
-    cxd: util.Quantity = field(
+    cxd: pace.util.Quantity = field(
         metadata={
             "name": "accumulated_x_courant_number",
-            "dims": [util.X_INTERFACE_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "",
             "n_halo": (0, 3),
             "intent": "inout",
         }
     )
-    cyd: util.Quantity = field(
+    cyd: pace.util.Quantity = field(
         metadata={
             "name": "accumulated_y_courant_number",
-            "dims": [util.X_DIM, util.Y_INTERFACE_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM, pace.util.Z_DIM],
             "units": "",
             "n_halo": (3, 0),
             "intent": "inout",
         }
     )
-    diss_estd: util.Quantity = field(
+    diss_estd: pace.util.Quantity = field(
         metadata={
             "name": "dissipation_estimate_from_heat_source",
-            "dims": [util.X_DIM, util.Y_DIM, util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "unknown",
             "n_halo": (3, 3),
             "intent": "inout",
         }
     )
-    phis: util.Quantity = field(
+    phis: pace.util.Quantity = field(
         metadata={
             "name": "surface_geopotential",
             "units": "m^2 s^-2",
-            "dims": [util.X_DIM, util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "intent": "in",
         }
     )
@@ -294,7 +294,7 @@ class DycoreState:
                         )
 
     @classmethod
-    def init_zeros(cls, quantity_factory: util.QuantityFactory):
+    def init_zeros(cls, quantity_factory: pace.util.QuantityFactory):
         initial_storages = {}
         for _field in fields(cls):
             if "dims" in _field.metadata.keys():
@@ -307,7 +307,7 @@ class DycoreState:
 
     @classmethod
     def init_from_numpy_arrays(
-        cls, dict_of_numpy_arrays, sizer: util.GridSizer, backend: str
+        cls, dict_of_numpy_arrays, sizer: pace.util.GridSizer, backend: str
     ):
         field_names = [_field.name for _field in fields(cls)]
         for variable_name in dict_of_numpy_arrays.keys():
@@ -319,7 +319,7 @@ class DycoreState:
         for _field in fields(cls):
             if "dims" in _field.metadata.keys():
                 dims = _field.metadata["dims"]
-                dict_state[_field.name] = util.Quantity(
+                dict_state[_field.name] = pace.util.Quantity(
                     dict_of_numpy_arrays[_field.name],
                     dims,
                     _field.metadata["units"],
@@ -334,7 +334,7 @@ class DycoreState:
     def init_from_storages(
         cls,
         storages: Mapping[str, Any],
-        sizer: util.GridSizer,
+        sizer: pace.util.GridSizer,
         do_adiabatic_init: bool = False,
         bdt: float = 0.0,
         mdt: float = 0.0,
@@ -343,7 +343,7 @@ class DycoreState:
         for _field in fields(cls):
             if "dims" in _field.metadata.keys():
                 dims = _field.metadata["dims"]
-                quantity = util.Quantity(
+                quantity = pace.util.Quantity(
                     storages[_field.name],
                     dims,
                     _field.metadata["units"],
@@ -357,7 +357,7 @@ class DycoreState:
     def xr_dataset(self):
         data_vars = {}
         for name, field_info in self.__dataclass_fields__.items():
-            if issubclass(field_info.type, util.Quantity):
+            if issubclass(field_info.type, pace.util.Quantity):
                 dims = [
                     f"{dim_name}_{name}" for dim_name in field_info.metadata["dims"]
                 ]

--- a/fv3core/fv3core/stencils/dyn_core.py
+++ b/fv3core/fv3core/stencils/dyn_core.py
@@ -371,6 +371,11 @@ class AcousticDynamics:
         self._temporaries = dyncore_temporaries(
             grid_indexing, backend=stencil_factory.backend
         )
+        # This is only here so the temporaries are attributes on this class,
+        # to more easily pick them up in unit testing
+        # if self._temporaries were a dataclass we can remove this
+        for name, value in self._temporaries.items():
+            setattr(self, f"_tmp_{name}", value)
         if not config.hydrostatic:
             self._temporaries["pk3"][:] = HUGE_R
 

--- a/fv3core/fv3core/stencils/dyn_core.py
+++ b/fv3core/fv3core/stencils/dyn_core.py
@@ -43,7 +43,6 @@ def zero_data(
     mfyd: FloatField,
     cxd: FloatField,
     cyd: FloatField,
-    heat_source: FloatField,
     diss_estd: FloatField,
     first_timestep: bool,
 ):
@@ -62,7 +61,6 @@ def zero_data(
         mfyd = 0.0
         cxd = 0.0
         cyd = 0.0
-        heat_source = 0.0
         if first_timestep:
             with horizontal(region[3:-3, 3:-3]):
                 diss_estd = 0.0
@@ -625,7 +623,6 @@ class AcousticDynamics:
             state.mfyd,
             state.cxd,
             state.cyd,
-            state.heat_source,
             state.diss_estd,
             state.n_map == 1,
         )

--- a/fv3core/fv3core/stencils/dyn_core.py
+++ b/fv3core/fv3core/stencils/dyn_core.py
@@ -43,6 +43,7 @@ def zero_data(
     mfyd: FloatField,
     cxd: FloatField,
     cyd: FloatField,
+    heat_source: FloatField,
     diss_estd: FloatField,
     first_timestep: bool,
 ):
@@ -52,6 +53,7 @@ def zero_data(
         mfyd (out):
         cxd (out):
         cyd (out):
+        heat_source (out):
         diss_estd (out):
         first_timestep (in):
     """
@@ -60,6 +62,7 @@ def zero_data(
         mfyd = 0.0
         cxd = 0.0
         cyd = 0.0
+        heat_source = 0.0
         if first_timestep:
             with horizontal(region[3:-3, 3:-3]):
                 diss_estd = 0.0
@@ -529,24 +532,24 @@ class AcousticDynamics:
         if self.call_checkpointer:
             self.checkpointer(
                 f"C_SW-{tag}",
-                delp=state.delp,
-                pt=state.pt,
-                u=state.u,
-                v=state.v,
-                w=state.w,
-                uc=state.uc,
-                vc=state.vc,
-                ua=state.ua,
-                va=state.va,
-                ut=state.ut,
-                vt=state.vt,
-                divgd=state.divgd,
+                delpd=state.delp,
+                ptd=state.pt,
+                ud=state.u,
+                vd=state.v,
+                wd=state.w,
+                ucd=state.uc,
+                vcd=state.vc,
+                uad=state.ua,
+                vad=state.va,
+                utd=state.ut,
+                vtd=state.vt,
+                divgdd=state.divgd,
             )
 
-    def _checkpoint_dsw(self, state, tag: str):
+    def _checkpoint_dsw_in(self, state):
         if self.call_checkpointer:
             self.checkpointer(
-                f"D_SW-{tag}",
+                "D_SW-In",
                 ucd=state.uc,
                 vcd=state.vc,
                 wd=state.w,
@@ -558,6 +561,27 @@ class AcousticDynamics:
                 uad=state.ua,
                 vad=state.va,
                 zhd=state.zh,
+                divgdd=state.divgd,
+                xfxd=state.xfx,
+                yfxd=state.yfx,
+                mfxd=state.mfxd,
+                mfyd=state.mfyd,
+            )
+
+    def _checkpoint_dsw_out(self, state):
+        if self.call_checkpointer:
+            self.checkpointer(
+                "D_SW-Out",
+                ucd=state.uc,
+                vcd=state.vc,
+                wd=state.w,
+                delpcd=state.delpc,
+                delpd=state.delp,
+                ud=state.u,
+                vd=state.v,
+                ptd=state.pt,
+                uad=state.ua,
+                vad=state.va,
                 divgdd=state.divgd,
                 xfxd=state.xfx,
                 yfxd=state.yfx,
@@ -601,6 +625,7 @@ class AcousticDynamics:
             state.mfyd,
             state.cxd,
             state.cyd,
+            state.heat_source,
             state.diss_estd,
             state.n_map == 1,
         )
@@ -714,7 +739,7 @@ class AcousticDynamics:
             self._halo_updaters.uc__vc.wait()
             # use the computed c-grid winds to evolve the d-grid winds forward
             # by 1 timestep
-            self._checkpoint_dsw(state, tag="In")
+            self._checkpoint_dsw_in(state)
             self.dgrid_shallow_water_lagrangian_dynamics(
                 state.vt,
                 state.delp,
@@ -741,7 +766,7 @@ class AcousticDynamics:
                 state.diss_estd,
                 dt,
             )
-            self._checkpoint_dsw(state, tag="Out")
+            self._checkpoint_dsw_out(state)
             # note that uc and vc are not needed at all past this point.
             # they will be re-computed from scratch on the next acoustic timestep.
 

--- a/fv3core/fv3core/stencils/dyn_core.py
+++ b/fv3core/fv3core/stencils/dyn_core.py
@@ -43,6 +43,7 @@ def zero_data(
     mfyd: FloatField,
     cxd: FloatField,
     cyd: FloatField,
+    heat_source: FloatField,
     diss_estd: FloatField,
     first_timestep: bool,
 ):
@@ -63,6 +64,7 @@ def zero_data(
         cyd = 0.0
         if first_timestep:
             with horizontal(region[3:-3, 3:-3]):
+                heat_source = 0.0
                 diss_estd = 0.0
 
 
@@ -628,6 +630,7 @@ class AcousticDynamics:
             state.mfyd,
             state.cxd,
             state.cyd,
+            state.heat_source,
             state.diss_estd,
             state.n_map == 1,
         )

--- a/fv3core/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/fv3core/stencils/fv_dynamics.py
@@ -327,6 +327,8 @@ class DynamicalCore:
         )
 
         self._temporaries = fvdyn_temporaries(quantity_factory)
+        for name, value in self._temporaries.items():
+            setattr(self, f"_tmp_{name}", value)
         if not (not self.config.inline_q and NQ != 0):
             raise NotImplementedError("tracer_2d not implemented, turn on z_tracer")
         self._adjust_tracer_mixing_ratio = AdjustNegativeTracerMixingRatio(

--- a/fv3core/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/fv3core/stencils/fv_dynamics.py
@@ -185,12 +185,12 @@ def wrapup(
 def fvdyn_temporaries(quantity_factory: pace.util.QuantityFactory):
     tmps = {}
     for name in ["te_2d", "te0_2d", "wsd"]:
-        quantity = quantity_factory.empty(
+        quantity = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM], units="unknown"
         )
         tmps[name] = quantity
     for name in ["cappa", "dp1", "cvm"]:
-        quantity = quantity_factory.empty(
+        quantity = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             units="unknown",
         )

--- a/fv3core/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/fv3core/stencils/fv_dynamics.py
@@ -327,6 +327,9 @@ class DynamicalCore:
         )
 
         self._temporaries = fvdyn_temporaries(quantity_factory)
+        # This is only here so the temporaries are attributes on this class,
+        # to more easily pick them up in unit testing
+        # if self._temporaries were a dataclass we can remove this
         for name, value in self._temporaries.items():
             setattr(self, f"_tmp_{name}", value)
         if not (not self.config.inline_q and NQ != 0):

--- a/fv3core/tests/main/dsl/test_stencil_factory.py
+++ b/fv3core/tests/main/dsl/test_stencil_factory.py
@@ -180,11 +180,13 @@ def test_stencil_factory_numpy_comparison_runs_without_exceptions():
     )
     factory = StencilFactory(config=config, grid_indexing=indexing)
     stencil = factory.from_origin_domain(
-        func=copy_stencil, origin=(0, 0, 0), domain=(12, 12, 79)
+        func=copy_stencil,
+        origin=(0, 0, 0),
+        domain=indexing.max_shape,
     )
     assert isinstance(stencil, CompareToNumpyStencil)
     q_in = make_storage_from_shape(indexing.max_shape, backend=backend)
-    q_in[:] = np.random.randn(*q_in.shape)
+    q_in.data[:] = np.random.randn(*q_in.data.shape)
     q_out = make_storage_from_shape(indexing.max_shape, backend=backend)
     stencil(q_in, q_out)
     np.testing.assert_array_equal(q_in.data, q_out.data)

--- a/fv3core/tests/main/dsl/test_stencil_factory.py
+++ b/fv3core/tests/main/dsl/test_stencil_factory.py
@@ -186,7 +186,7 @@ def test_stencil_factory_numpy_comparison_runs_without_exceptions():
     )
     assert isinstance(stencil, CompareToNumpyStencil)
     q_in = make_storage_from_shape(indexing.max_shape, backend=backend)
-    q_in[:] = np.random.randn(*q_in.shape)
+    q_in.data[:] = np.random.randn(*q_in.data.shape)
     q_out = make_storage_from_shape(indexing.max_shape, backend=backend)
     stencil(q_in, q_out)
     np.testing.assert_array_equal(q_in.data, q_out.data)

--- a/fv3core/tests/main/dsl/test_stencil_factory.py
+++ b/fv3core/tests/main/dsl/test_stencil_factory.py
@@ -186,7 +186,7 @@ def test_stencil_factory_numpy_comparison_runs_without_exceptions():
     )
     assert isinstance(stencil, CompareToNumpyStencil)
     q_in = make_storage_from_shape(indexing.max_shape, backend=backend)
-    q_in.data[:] = np.random.randn(*q_in.data.shape)
+    q_in[:] = np.random.randn(*q_in.shape)
     q_out = make_storage_from_shape(indexing.max_shape, backend=backend)
     stencil(q_in, q_out)
     np.testing.assert_array_equal(q_in.data, q_out.data)

--- a/fv3core/tests/main/test_dycore_call.py
+++ b/fv3core/tests/main/test_dycore_call.py
@@ -147,7 +147,9 @@ def _assert_same_temporaries(dict1: dict, dict2: dict) -> List[str]:
         attr2 = dict2[attr]
         if isinstance(attr1, np.ndarray):
             try:
-                np.testing.assert_array_equal(attr1, attr2, err_msg=f"{attr} not equal")
+                np.testing.assert_almost_equal(
+                    attr1, attr2, err_msg=f"{attr} not equal"
+                )
             except AssertionError:
                 differences.append(attr)
         else:
@@ -197,7 +199,7 @@ def test_temporaries_are_deterministic():
 
 def test_call_on_same_state_same_dycore_produces_same_temporaries():
     """
-    Assuming the precursor test passses, this test indicates whether
+    Assuming the precursor test passes, this test indicates whether
     the dycore retains and re-uses internal state on subsequent calls.
     If it does not, then subsequent calls on identical input should
     produce identical results.

--- a/fv3core/tests/main/test_dycore_call.py
+++ b/fv3core/tests/main/test_dycore_call.py
@@ -1,7 +1,10 @@
-import contextlib
+import copy
 import os
 import unittest.mock
 from typing import Any, List, Tuple
+
+import gt4py.storage.storage
+import numpy as np
 
 import fv3core
 import fv3core._config
@@ -14,37 +17,6 @@ from pace.util.null_comm import NullComm
 
 
 DIR = os.path.abspath(os.path.dirname(__file__))
-
-
-@contextlib.contextmanager
-def no_lagrangian_contributions(dynamical_core: fv3core.DynamicalCore):
-    # TODO: lagrangian contributions currently cause an out of bounds iteration
-    # when halo updates are disabled. Fix that bug and remove this decorator.
-    # Probably requires an update to gt4py (currently v36).
-    def do_nothing(*args, **kwargs):
-        pass
-
-    original_attributes = {}
-    for obj in (
-        dynamical_core._lagrangian_to_eulerian_obj._map_single_delz,
-        dynamical_core._lagrangian_to_eulerian_obj._map_single_pt,
-        dynamical_core._lagrangian_to_eulerian_obj._map_single_u,
-        dynamical_core._lagrangian_to_eulerian_obj._map_single_v,
-        dynamical_core._lagrangian_to_eulerian_obj._map_single_w,
-        dynamical_core._lagrangian_to_eulerian_obj._map_single_delz,
-    ):
-        original_attributes[obj] = obj._lagrangian_contributions
-        obj._lagrangian_contributions = do_nothing  # type: ignore
-    for (
-        obj
-    ) in dynamical_core._lagrangian_to_eulerian_obj._mapn_tracer._list_of_remap_objects:
-        original_attributes[obj] = obj._lagrangian_contributions
-        obj._lagrangian_contributions = do_nothing  # type: ignore
-    try:
-        yield
-    finally:
-        for obj, original in original_attributes.items():
-            obj._lagrangian_contributions = original
 
 
 def setup_dycore() -> Tuple[fv3core.DynamicalCore, List[Any]]:
@@ -162,6 +134,85 @@ def setup_dycore() -> Tuple[fv3core.DynamicalCore, List[Any]]:
     return dycore, args
 
 
+def assert_same_temporaries(dict1: dict, dict2: dict):
+    diffs = _assert_same_temporaries(dict1, dict2)
+    if len(diffs) > 0:
+        raise AssertionError(f"{len(diffs)} differing temporaries found: {diffs}")
+
+
+def _assert_same_temporaries(dict1: dict, dict2: dict) -> List[str]:
+    differences = []
+    for attr in dict1:
+        attr1 = dict1[attr]
+        attr2 = dict2[attr]
+        if isinstance(attr1, np.ndarray):
+            try:
+                np.testing.assert_array_equal(attr1, attr2, err_msg=f"{attr} not equal")
+            except AssertionError:
+                differences.append(attr)
+        else:
+            sub_differences = _assert_same_temporaries(attr1, attr2)
+            for d in sub_differences:
+                differences.append(f"{attr}.{d}")
+    return differences
+
+
+def copy_temporaries(obj, max_depth: int) -> dict:
+    temporaries = {}
+    attrs = [a for a in dir(obj) if not a.startswith("__")]
+    for attr_name in attrs:
+        try:
+            attr = getattr(obj, attr_name)
+        except AttributeError:
+            attr = None
+        if isinstance(attr, (gt4py.storage.storage.Storage, pace.util.Quantity)):
+            temporaries[attr_name] = copy.deepcopy(np.asarray(attr.data))
+        elif attr.__class__.__module__.split(".")[0] in ("fv3core", "pace"):
+            if max_depth > 0:
+                sub_temporaries = copy_temporaries(attr, max_depth - 1)
+                if len(sub_temporaries) > 0:
+                    temporaries[attr_name] = sub_temporaries
+    return temporaries
+
+
+def test_temporaries_are_deterministic():
+    """
+    This is a precursor test to the next one, ensuring that two
+    identically-initialized dycores called on identically-initialized
+    states produce identical temporaries.
+
+    This will fail if there is non-determinism in the initialization,
+    for example from using `empty` instead of `zeros` to initialize data.
+    """
+    dycore1, args1 = setup_dycore()
+    dycore2, args2 = setup_dycore()
+
+    dycore1.step_dynamics(*args1)
+    first_temporaries = copy_temporaries(dycore1, max_depth=10)
+    assert len(first_temporaries) > 0
+    dycore2.step_dynamics(*args2)
+    second_temporaries = copy_temporaries(dycore2, max_depth=10)
+    assert_same_temporaries(second_temporaries, first_temporaries)
+
+
+def test_call_on_same_state_same_dycore_produces_same_temporaries():
+    """
+    Assuming the precursor test passses, this test indicates whether
+    the dycore retains and re-uses internal state on subsequent calls.
+    If it does not, then subsequent calls on identical input should
+    produce identical results.
+    """
+    dycore, args1 = setup_dycore()
+    _, args2 = setup_dycore()
+
+    dycore.step_dynamics(*args1)
+    first_temporaries = copy_temporaries(dycore, max_depth=10)
+    assert len(first_temporaries) > 0
+    dycore.step_dynamics(*args2)
+    second_temporaries = copy_temporaries(dycore, max_depth=10)
+    assert_same_temporaries(second_temporaries, first_temporaries)
+
+
 def test_call_does_not_allocate_storages():
     dycore, args = setup_dycore()
 
@@ -170,8 +221,7 @@ def test_call_does_not_allocate_storages():
 
     with unittest.mock.patch("gt4py.storage.storage.zeros", new=error_func):
         with unittest.mock.patch("gt4py.storage.storage.empty", new=error_func):
-            with no_lagrangian_contributions(dynamical_core=dycore):
-                dycore.step_dynamics(*args)
+            dycore.step_dynamics(*args)
 
 
 def test_call_does_not_define_stencils():
@@ -181,5 +231,4 @@ def test_call_does_not_define_stencils():
         raise AssertionError("call not allowed")
 
     with unittest.mock.patch("gt4py.gtscript.stencil", new=error_func):
-        with no_lagrangian_contributions(dynamical_core=dycore):
-            dycore.step_dynamics(*args)
+        dycore.step_dynamics(*args)

--- a/fv3core/tests/main/test_dycore_call.py
+++ b/fv3core/tests/main/test_dycore_call.py
@@ -202,13 +202,15 @@ def test_call_on_same_state_same_dycore_produces_same_temporaries():
     If it does not, then subsequent calls on identical input should
     produce identical results.
     """
-    dycore, args1 = setup_dycore()
-    _, args2 = setup_dycore()
+    dycore, state_1 = setup_dycore()
+    _, state_2 = setup_dycore()
 
-    dycore.step_dynamics(*args1)
+    # state_1 and state_2 are identical, if the dycore is stateless then they
+    # should produce identical dycore final states when used to call
+    dycore.step_dynamics(*state_1)
     first_temporaries = copy_temporaries(dycore, max_depth=10)
     assert len(first_temporaries) > 0
-    dycore.step_dynamics(*args2)
+    dycore.step_dynamics(*state_2)
     second_temporaries = copy_temporaries(dycore, max_depth=10)
     assert_same_temporaries(second_temporaries, first_temporaries)
 

--- a/fv3gfs-physics/fv3gfs/physics/stencils/microphysics.py
+++ b/fv3gfs-physics/fv3gfs/physics/stencils/microphysics.py
@@ -1935,18 +1935,18 @@ class Microphysics:
                 shape, origin=origin, backend=stencil_factory.backend, **kwargs
             )
 
-        self._land = make_storage(init=True)
-        self._rain = make_storage(init=True)
-        self._graupel = make_storage(init=True)
-        self._ice = make_storage(init=True)
-        self._snow = make_storage(init=True)
+        self._land = make_storage()
+        self._rain = make_storage()
+        self._graupel = make_storage()
+        self._ice = make_storage()
+        self._snow = make_storage()
 
         self._h_var = make_storage()
         self._rh_adj = make_storage()
         self._rh_rain = make_storage()
 
-        self._qn = make_storage(init=True)
-        self._qaz = make_storage(init=True)
+        self._qn = make_storage()
+        self._qaz = make_storage()
         self._qgz = make_storage()
         self._qiz = make_storage()
         self._qlz = make_storage()
@@ -1974,15 +1974,15 @@ class Microphysics:
         self._p1 = make_storage()
         self._u1 = make_storage()
         self._v1 = make_storage()
-        self._m1 = make_storage(init=True)
+        self._m1 = make_storage()
         self._vtgz = make_storage()
         self._vtrz = make_storage()
         self._vtsz = make_storage()
         self._ccn = make_storage()
         self._c_praut = make_storage()
         self._m1_sol = make_storage()
-        self._m2_rain = make_storage(init=True)
-        self._m2_sol = make_storage(init=True)
+        self._m2_rain = make_storage()
+        self._m2_sol = make_storage()
 
         self._so3 = 7.0 / 3.0
         self._zs = 0.0

--- a/fv3gfs-physics/fv3gfs/physics/stencils/physics.py
+++ b/fv3gfs-physics/fv3gfs/physics/stencils/physics.py
@@ -185,7 +185,7 @@ class Physics:
 
         def make_storage():
             return utils.make_storage_from_shape(
-                shape, origin=origin, init=True, backend=stencil_factory.backend
+                shape, origin=origin, backend=stencil_factory.backend
             )
 
         self._prsik = make_storage()

--- a/fv3gfs-physics/tests/savepoint/translate/translate_atmos_phy_statein.py
+++ b/fv3gfs-physics/tests/savepoint/translate/translate_atmos_phy_statein.py
@@ -99,13 +99,11 @@ class TranslateAtmosPhysDriverStatein(TranslatePhysicsFortranData2Py):
         qsgs_tke = utils.make_storage_from_shape(
             self.maxshape,
             origin=(0, 0, 0),
-            init=True,
             backend=self.stencil_factory.backend,
         )
         dm = utils.make_storage_from_shape(
             self.maxshape,
             origin=(0, 0, 0),
-            init=True,
             backend=self.stencil_factory.backend,
         )
         inputs["qsgs_tke"] = qsgs_tke

--- a/fv3gfs-physics/tests/savepoint/translate/translate_gfs_physics_driver.py
+++ b/fv3gfs-physics/tests/savepoint/translate/translate_gfs_physics_driver.py
@@ -91,7 +91,6 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
         storage = utils.make_storage_from_shape(
             self.grid_indexing.domain_full(add=(1, 1, 1)),
             origin=self.grid_indexing.origin_compute(),
-            init=True,
             backend=self.stencil_factory.backend,
         )
         inputs["delprsi"] = copy.deepcopy(storage)

--- a/fv3gfs-physics/tests/savepoint/translate/translate_microphysics.py
+++ b/fv3gfs-physics/tests/savepoint/translate/translate_microphysics.py
@@ -49,7 +49,6 @@ class TranslateMicroph(TranslatePhysicsFortranData2Py):
         storage = utils.make_storage_from_shape(
             self.grid_indexing.domain_full(add=(1, 1, 1)),
             origin=self.grid_indexing.origin_compute(),
-            init=True,
             backend=self.stencil_factory.backend,
         )
         inputs["qo3mr"] = copy.deepcopy(storage)

--- a/stencils/pace/stencils/fv_update_phys.py
+++ b/stencils/pace/stencils/fv_update_phys.py
@@ -124,10 +124,10 @@ class ApplyPhysicsToDycore:
         )
         # TODO: check if we actually need surface winds
         self._u_srf = utils.make_storage_from_shape(
-            shape[0:2], origin=self.origin, init=True, backend=stencil_factory.backend
+            shape[0:2], origin=self.origin, backend=stencil_factory.backend
         )
         self._v_srf = utils.make_storage_from_shape(
-            shape[0:2], origin=self.origin, init=True, backend=stencil_factory.backend
+            shape[0:2], origin=self.origin, backend=stencil_factory.backend
         )
 
     def __call__(

--- a/stencils/pace/stencils/update_dwind_phys.py
+++ b/stencils/pace/stencils/update_dwind_phys.py
@@ -178,9 +178,7 @@ class AGrid2DGridPhysics:
         self.east_edge = grid_indexing.east_edge
 
         def make_storage():
-            return utils.make_storage_from_shape(
-                shape, init=True, backend=stencil_factory.backend
-            )
+            return utils.make_storage_from_shape(shape, backend=stencil_factory.backend)
 
         self._ue_1 = make_storage()
         self._ue_2 = make_storage()


### PR DESCRIPTION
## Purpose

Due to heat_source not being re-initialized to zero at the appropriate point where it is done in the Fortran code, the dycore was retaining model state and producing incorrect behavior on subsequent timesteps. This PR fixes that issue. It also adds a unit test which ensures temporaries kept as attributes on our objects do not retain model state between calls. It does this by ensuring that if a dycore is called twice with the same model state, the resulting temporaries should be identical.

## Code changes:

- Fixed bug where heat_source and diss_est were not zeroed when first used in D_SW
- Added test that if a dycore is called twice with the same model state, the resulting temporaries should be identical.
- lagrangian contributions is no longer excluded from dycore main tests, since it no longer causes an exception on the numpy backend
- init is no longer an argument to `make_storage_from_shape`, instead it always initializes zeros

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
