### PR TITLE
hotfix grid for caching

### DIFF
--- a/driver/pace/driver/initialization.py
+++ b/driver/pace/driver/initialization.py
@@ -233,9 +233,7 @@ class SerialboxConfig(Initializer):
             quantity_factory=quantity_factory,
             active_packages=["microphysics"],
         )
-        tendency_state = TendencyState.init_zeros(
-            quantity_factory=quantity_factory,
-        )
+        tendency_state = TendencyState.init_zeros(quantity_factory=quantity_factory)
         return DriverState(
             dycore_state=dycore_state,
             physics_state=physics_state,
@@ -261,13 +259,11 @@ class SerialboxConfig(Initializer):
         )
         ser = self._serializer(communicator)
         savepoint_in = ser.get_savepoint("Driver-In")[0]
-        stencil_config = pace.dsl.stencil.StencilConfig(
-            backend=backend,
-        )
+        stencil_config = pace.dsl.stencil.StencilConfig(backend=backend)
         stencil_factory = StencilFactory(
             config=stencil_config, grid_indexing=grid.grid_indexing
         )
-        translate_object = TranslateFVDynamics([grid], self._namelist, stencil_factory)
+        translate_object = TranslateFVDynamics(grid, self._namelist, stencil_factory)
         input_data = translate_object.collect_input_data(ser, savepoint_in)
         dycore_state = translate_object.state_from_inputs(input_data)
         return dycore_state

--- a/fv3core/examples/standalone/runfile/dynamics.py
+++ b/fv3core/examples/standalone/runfile/dynamics.py
@@ -179,7 +179,7 @@ def read_serialized_initial_state(rank, grid, namelist, stencil_factory, data_di
     )
     # create a state from serialized data
     savepoint_in = serializer.get_savepoint("Driver-In")[0]
-    driver_object = TranslateFVDynamics([grid], namelist, stencil_factory)
+    driver_object = TranslateFVDynamics(grid, namelist, stencil_factory)
     input_data = driver_object.collect_input_data(serializer, savepoint_in)
     state = driver_object.state_from_inputs(input_data)
     return state


### PR DESCRIPTION
## Purpose

Small hotfix in the `driver/initialization.py` and `examples/standalone/runfile/dynamics.py` files where and outdated way of passing the grid was used.



## Code changes:

- replaces instances of `[grid]` with `grid` for the Initialization of the `TranslateFVDynamics` object.


