### PR TITLE
Refactor dycore translate tests to use Namelist class

### DIFF
--- a/fv3core/fv3core/testing/translate_fvdynamics.py
+++ b/fv3core/fv3core/testing/translate_fvdynamics.py
@@ -4,8 +4,9 @@ from typing import Any, Dict, Optional
 import pytest
 
 import fv3core.stencils.fv_dynamics as fv_dynamics
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
-import pace.util as fv3util
+import pace.util
 from fv3core._config import DynamicalCoreConfig
 from fv3core.initialization.dycore_state import DycoreState
 from pace.stencils.testing import ParallelTranslateBaseSlicing
@@ -19,180 +20,180 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
     inputs: Dict[str, Any] = {
         "q_con": {
             "name": "total_condensate_mixing_ratio",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
         },
         "delp": {
             "name": "pressure_thickness_of_atmospheric_layer",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "Pa",
         },
         "delz": {
             "name": "vertical_thickness_of_atmospheric_layer",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m",
         },
         "ps": {
             "name": "surface_pressure",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "Pa",
         },
         "pe": {
             "name": "interface_pressure",
-            "dims": [fv3util.X_DIM, fv3util.Z_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Z_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "Pa",
             "n_halo": 1,
         },
         "ak": {
             "name": "atmosphere_hybrid_a_coordinate",
-            "dims": [fv3util.Z_INTERFACE_DIM],
+            "dims": [pace.util.Z_INTERFACE_DIM],
             "units": "Pa",
         },
         "bk": {
             "name": "atmosphere_hybrid_b_coordinate",
-            "dims": [fv3util.Z_INTERFACE_DIM],
+            "dims": [pace.util.Z_INTERFACE_DIM],
             "units": "",
         },
         "pk": {
             "name": "interface_pressure_raised_to_power_of_kappa",
             "units": "unknown",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_INTERFACE_DIM],
             "n_halo": 0,
         },
         "pkz": {
             "name": "layer_mean_pressure_raised_to_power_of_kappa",
             "units": "unknown",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "n_halo": 0,
         },
         "peln": {
             "name": "logarithm_of_interface_pressure",
             "units": "ln(Pa)",
-            "dims": [fv3util.X_DIM, fv3util.Z_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Z_INTERFACE_DIM, pace.util.Y_DIM],
             "n_halo": 0,
         },
         "mfxd": {
             "name": "accumulated_x_mass_flux",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "unknown",
             "n_halo": 0,
         },
         "mfyd": {
             "name": "accumulated_y_mass_flux",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM, pace.util.Z_DIM],
             "units": "unknown",
             "n_halo": 0,
         },
         "cxd": {
             "name": "accumulated_x_courant_number",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "",
             "n_halo": (0, 3),
         },
         "cyd": {
             "name": "accumulated_y_courant_number",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM, pace.util.Z_DIM],
             "units": "",
             "n_halo": (3, 0),
         },
         "diss_estd": {
             "name": "dissipation_estimate_from_heat_source",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "unknown",
         },
         "pt": {
             "name": "air_temperature",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "degK",
         },
         "u": {
             "name": "x_wind",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM, pace.util.Z_DIM],
             "units": "m/s",
         },
         "v": {
             "name": "y_wind",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
         },
         "ua": {
             "name": "eastward_wind",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
         },
         "va": {
             "name": "northward_wind",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
         },
         "uc": {
             "name": "x_wind_on_c_grid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
         },
         "vc": {
             "name": "y_wind_on_c_grid",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM, pace.util.Z_DIM],
             "units": "m/s",
         },
         "w": {
             "name": "vertical_wind",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m/s",
         },
         "phis": {
             "name": "surface_geopotential",
             "units": "m^2 s^-2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
         },
         "qvapor": {
             "name": "specific_humidity",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
         },
         "qliquid": {
             "name": "cloud_water_mixing_ratio",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
         },
         "qice": {
             "name": "cloud_ice_mixing_ratio",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
         },
         "qrain": {
             "name": "rain_mixing_ratio",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
         },
         "qsnow": {
             "name": "snow_mixing_ratio",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
         },
         "qgraupel": {
             "name": "graupel_mixing_ratio",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
         },
         "qo3mr": {
             "name": "ozone_mixing_ratio",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "kg/kg",
         },
         "qsgs_tke": {
             "name": "turbulent_kinetic_energy",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "m**2/s**2",
         },
         "qcld": {
             "name": "cloud_fraction",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "",
         },
         "omga": {
             "name": "vertical_pressure_velocity",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "Pa/s",
         },
         "do_adiabatic_init": {"dims": []},
@@ -206,7 +207,14 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
     for name in ("do_adiabatic_init", "bdt", "ak", "bk", "ks", "ptop"):
         outputs.pop(name)
 
-    def __init__(self, grid, namelist, stencil_factory, *args, **kwargs):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+        *args,
+        **kwargs,
+    ):
         super().__init__(grid, namelist, stencil_factory, *args, **kwargs)
         fv_dynamics_vars = {
             "u": grid.y3d_domain_dict(),
@@ -308,7 +316,7 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
             grid_data=grid_data,
             stencil_factory=self.stencil_factory,
             damping_coefficients=self.grid.damping_coefficients,
-            config=self.namelist,
+            config=DynamicalCoreConfig.from_namelist(self.namelist),
             phis=state.phis,
         )
         self.dycore.step_dynamics(
@@ -329,7 +337,7 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
         outputs = {}
         storages = {}
         for name, properties in self.outputs.items():
-            if isinstance(state[name], fv3util.Quantity):
+            if isinstance(state[name], pace.util.Quantity):
                 storages[name] = state[name].storage
             elif len(self.outputs[name]["dims"]) > 0:
                 storages[name] = state[name]  # assume it's a storage

--- a/fv3core/tests/savepoint/translate/translate_a2b_ord4.py
+++ b/fv3core/tests/savepoint/translate/translate_a2b_ord4.py
@@ -1,3 +1,7 @@
+from typing import Any, Dict
+
+import pace.dsl
+import pace.util
 from fv3core.stencils.divergence_damping import DivergenceDamping
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
@@ -21,11 +25,16 @@ def compute(divdamp, wk, vort, delpc, dt):
 
 
 class TranslateA2B_Ord4(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {"wk": {}, "vort": {}, "delpc": {}, "nord_col": {}}
         self.in_vars["parameters"] = ["dt"]
-        self.out_vars = {"wk": {}, "vort": {}}
+        self.out_vars: Dict[str, Any] = {"wk": {}, "vort": {}}
         self.namelist = namelist
         self.stencil_factory = stencil_factory
 

--- a/fv3core/tests/savepoint/translate/translate_c_sw.py
+++ b/fv3core/tests/savepoint/translate/translate_c_sw.py
@@ -1,8 +1,12 @@
+import pace.dsl
+import pace.util
 from fv3core.stencils.c_sw import CGridShallowWaterDynamics
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
-def get_c_sw_instance(grid, namelist, stencil_factory):
+def get_c_sw_instance(
+    grid, namelist: pace.util.Namelist, stencil_factory: pace.dsl.StencilFactory
+):
     return CGridShallowWaterDynamics(
         stencil_factory,
         grid.grid_data,
@@ -60,7 +64,12 @@ def compute_vorticitytransport_cgrid(
 
 
 class TranslateC_SW(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         cgrid_shallow_water_lagrangian_dynamics = get_c_sw_instance(
             grid, namelist, stencil_factory
@@ -101,7 +110,12 @@ class TranslateC_SW(TranslateDycoreFortranData2Py):
 
 
 class TranslateDivergenceCorner(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.max_error = 9e-10
         self.cgrid_sw_lagrangian_dynamics = get_c_sw_instance(
@@ -154,7 +168,12 @@ class TranslateDivergenceCorner(TranslateDycoreFortranData2Py):
 
 
 class TranslateCirculation_Cgrid(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.max_error = 5e-9
         self.cgrid_sw_lagrangian_dynamics = get_c_sw_instance(
@@ -191,7 +210,12 @@ class TranslateCirculation_Cgrid(TranslateDycoreFortranData2Py):
 
 
 class TranslateVorticityTransport_Cgrid(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         cgrid_sw_lagrangian_dynamics = get_c_sw_instance(
             grid, namelist, stencil_factory

--- a/fv3core/tests/savepoint/translate/translate_corners.py
+++ b/fv3core/tests/savepoint/translate/translate_corners.py
@@ -1,14 +1,23 @@
+from typing import Any, Dict
+
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from pace.stencils import corners
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateFill4Corners(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {"q4c": {}}
         self.in_vars["parameters"] = ["dir"]
-        self.out_vars = {"q4c": {}}
+        self.out_vars: Dict[str, Any] = {"q4c": {}}
         self.stencil_factory = stencil_factory
 
     def compute(self, inputs):
@@ -35,7 +44,12 @@ class TranslateFill4Corners(TranslateDycoreFortranData2Py):
 
 
 class TranslateFillCorners(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {"divg_d": {}, "nord_col": {}}
         self.in_vars["parameters"] = ["dir"]
@@ -77,11 +91,16 @@ class TranslateFillCorners(TranslateDycoreFortranData2Py):
 
 
 class TranslateCopyCorners(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {"q": {}}
         self.in_vars["parameters"] = ["dir"]
-        self.out_vars = {"q": {}}
+        self.out_vars: Dict[str, Any] = {"q": {}}
         self._copy_corners_x = corners.CopyCorners("x", stencil_factory=stencil_factory)
         self._copy_corners_y = corners.CopyCorners("y", stencil_factory=stencil_factory)
         self.stencil_factory = stencil_factory
@@ -97,10 +116,18 @@ class TranslateCopyCorners(TranslateDycoreFortranData2Py):
 
 
 class TranslateFillCornersVector(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {"vc": {}, "uc": {}, "nord_col": {}}
-        self.out_vars = {"vc": grid.y3d_domain_dict(), "uc": grid.x3d_domain_dict()}
+        self.out_vars: Dict[str, Any] = {
+            "vc": grid.y3d_domain_dict(),
+            "uc": grid.x3d_domain_dict(),
+        }
         self.stencil_factory = stencil_factory
 
     def compute(self, inputs):

--- a/fv3core/tests/savepoint/translate/translate_cubedtolatlon.py
+++ b/fv3core/tests/savepoint/translate/translate_cubedtolatlon.py
@@ -1,3 +1,5 @@
+import pace.dsl
+import pace.util
 import pace.util as fv3util
 from pace.stencils.c2l_ord import CubedToLatLon
 from pace.stencils.testing import ParallelTranslate2Py
@@ -15,7 +17,12 @@ class TranslateCubedToLatLon(ParallelTranslate2Py):
         },
     }
 
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self._base.compute_func = CubedToLatLon(
             stencil_factory, grid.grid_data, order=namelist.c2l_ord

--- a/fv3core/tests/savepoint/translate/translate_d2a2c_vect.py
+++ b/fv3core/tests/savepoint/translate/translate_d2a2c_vect.py
@@ -1,9 +1,16 @@
+import pace.dsl
+import pace.util
 from fv3core.stencils.d2a2c_vect import DGrid2AGrid2CGridVectors
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateD2A2C_Vect(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         dord4 = True
         self.stencil_factory = stencil_factory

--- a/fv3core/tests/savepoint/translate/translate_d_sw.py
+++ b/fv3core/tests/savepoint/translate/translate_d_sw.py
@@ -1,12 +1,20 @@
 from gt4py.gtscript import PARALLEL, computation, interval
 
+import fv3core
 import fv3core.stencils.d_sw as d_sw
+import pace.dsl
+import pace.util
 from pace.dsl.typing import FloatField, FloatFieldIJ
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateD_SW(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.max_error = 3.2e-10
         self.stencil_factory = stencil_factory
@@ -14,6 +22,7 @@ class TranslateD_SW(TranslateDycoreFortranData2Py):
             namelist, grid.npz, backend=self.stencil_factory.backend
         )
         self.stencil_factory = stencil_factory
+        dycore_config = fv3core.DynamicalCoreConfig.from_namelist(namelist)
         self.compute_func = d_sw.DGridShallowWaterLagrangianDynamics(
             self.stencil_factory,
             self.grid.grid_data,
@@ -21,7 +30,7 @@ class TranslateD_SW(TranslateDycoreFortranData2Py):
             column_namelist,
             nested=self.grid.nested,
             stretched_grid=self.grid.stretched_grid,
-            config=namelist.d_grid_shallow_water,
+            config=dycore_config.d_grid_shallow_water,
         )
         self.in_vars["data_vars"] = {
             "uc": grid.x3d_domain_dict(),
@@ -72,7 +81,12 @@ def ubke(
 
 
 class TranslateUbKE(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "uc": {},
@@ -114,7 +128,12 @@ def vbke(
 
 
 class TranslateVbKE(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "vc": {},
@@ -140,7 +159,12 @@ class TranslateVbKE(TranslateDycoreFortranData2Py):
 
 
 class TranslateFluxCapacitor(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "cx": grid.x3d_compute_domain_y_dict(),
@@ -164,7 +188,12 @@ class TranslateFluxCapacitor(TranslateDycoreFortranData2Py):
 
 
 class TranslateHeatDiss(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "fx2": {},
@@ -203,7 +232,12 @@ class TranslateHeatDiss(TranslateDycoreFortranData2Py):
 
 
 class TranslateWdivergence(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "q": {"serialname": "w"},

--- a/fv3core/tests/savepoint/translate/translate_del2cubed.py
+++ b/fv3core/tests/savepoint/translate/translate_del2cubed.py
@@ -1,13 +1,22 @@
+from typing import Any, Dict
+
+import pace.dsl
+import pace.util
 from fv3core.stencils.del2cubed import HyperdiffusionDamping
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateDel2Cubed(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {"qdel": {}}
         self.in_vars["parameters"] = ["nmax", "cd"]
-        self.out_vars = {"qdel": {}}
+        self.out_vars: Dict[str, Any] = {"qdel": {}}
         self.stencil_factory = stencil_factory
 
     def compute_from_storage(self, inputs):

--- a/fv3core/tests/savepoint/translate/translate_del6vtflux.py
+++ b/fv3core/tests/savepoint/translate/translate_del6vtflux.py
@@ -1,9 +1,16 @@
 import fv3core.stencils.delnflux as delnflux
+import pace.dsl
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateDel6VtFlux(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         fxstat = grid.x3d_domain_dict()
         fxstat.update({"serialname": "fx2"})

--- a/fv3core/tests/savepoint/translate/translate_delnflux.py
+++ b/fv3core/tests/savepoint/translate/translate_delnflux.py
@@ -1,9 +1,16 @@
 import fv3core.stencils.delnflux as delnflux
+import pace.dsl
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateDelnFlux(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "q": {},
@@ -34,6 +41,11 @@ class TranslateDelnFlux(TranslateDycoreFortranData2Py):
 
 
 class TranslateDelnFlux_2(TranslateDelnFlux):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         del self.in_vars["data_vars"]["mass"]

--- a/fv3core/tests/savepoint/translate/translate_divergencedamping.py
+++ b/fv3core/tests/savepoint/translate/translate_divergencedamping.py
@@ -1,11 +1,18 @@
 from typing import Optional
 
 import fv3core.stencils.divergence_damping
+import pace.dsl
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateDivergenceDamping(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "u": {},

--- a/fv3core/tests/savepoint/translate/translate_fillz.py
+++ b/fv3core/tests/savepoint/translate/translate_fillz.py
@@ -1,12 +1,19 @@
 import numpy as np
 
 import fv3core.stencils.fillz as fillz
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py, pad_field_in_j
 
 
 class TranslateFillz(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "dp2": {"istart": grid.is_, "iend": grid.ie, "axis": 1},

--- a/fv3core/tests/savepoint/translate/translate_fvsubgridz.py
+++ b/fv3core/tests/savepoint/translate/translate_fvsubgridz.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
 
 import fv3core.stencils.fv_subgridz as fv_subgridz
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 import pace.util as fv3util
 from pace.stencils.testing import ParallelTranslateBaseSlicing
 
@@ -121,7 +123,14 @@ class TranslateFVSubgridZ(ParallelTranslateBaseSlicing):
     for name in ("dt", "pe", "peln", "delp", "delz", "pkz"):
         outputs.pop(name)
 
-    def __init__(self, grid, namelist, stencil_factory, *args, **kwargs):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+        *args,
+        **kwargs,
+    ):
         super().__init__(grid, namelist, stencil_factory, *args, **kwargs)
         self._base.in_vars["data_vars"] = {
             "pe": {

--- a/fv3core/tests/savepoint/translate/translate_fvtp2d.py
+++ b/fv3core/tests/savepoint/translate/translate_fvtp2d.py
@@ -1,10 +1,17 @@
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from fv3core.stencils.fvtp2d import FiniteVolumeTransport
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateFvTp2d(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "q": {},
@@ -61,7 +68,12 @@ class TranslateFvTp2d(TranslateDycoreFortranData2Py):
 
 
 class TranslateFvTp2d_2(TranslateFvTp2d):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         del self.in_vars["data_vars"]["mass"]
         del self.in_vars["data_vars"]["x_mass_flux"]

--- a/fv3core/tests/savepoint/translate/translate_fxadv.py
+++ b/fv3core/tests/savepoint/translate/translate_fxadv.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import pace.dsl
 import pace.util
 from fv3core.stencils.fxadv import FiniteVolumeFluxPrep
 from fv3core.utils.functional_validation import get_subset_func
@@ -7,7 +8,12 @@ from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateFxAdv(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         utinfo = grid.x3d_domain_dict()
         utinfo["serialname"] = "ut"

--- a/fv3core/tests/savepoint/translate/translate_grid.py
+++ b/fv3core/tests/savepoint/translate/translate_grid.py
@@ -3,8 +3,9 @@ from typing import Any, Dict
 import numpy as np
 import pytest
 
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
-import pace.util as fv3util
+import pace.util
 from fv3core.stencils.a2b_ord4 import AGrid2BGridFourthOrder
 from pace.stencils.testing.parallel_translate import ParallelTranslateGrid
 from pace.util.grid import MetricTerms, set_hybrid_pressure_coefficients
@@ -18,13 +19,13 @@ class TranslateGnomonicGrids(ParallelTranslateGrid):
     inputs = {
         "lon": {
             "name": "longitude_on_cell_corners",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "radians",
             "n_halo": 0,
         },
         "lat": {
             "name": "latitude_on_cell_corners",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "radians",
             "n_halo": 0,
         },
@@ -32,13 +33,13 @@ class TranslateGnomonicGrids(ParallelTranslateGrid):
     outputs = {
         "lon": {
             "name": "longitude_on_cell_corners",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "radians",
             "n_halo": 0,
         },
         "lat": {
             "name": "latitude_on_cell_corners",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "radians",
             "n_halo": 0,
         },
@@ -70,8 +71,8 @@ class TranslateMirrorGrid(ParallelTranslateGrid):
         "master_grid_global": {
             "name": "grid_global",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
                 MetricTerms.TILE_DIM,
             ],
@@ -86,8 +87,8 @@ class TranslateMirrorGrid(ParallelTranslateGrid):
         "master_grid_global": {
             "name": "grid_global",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
                 MetricTerms.TILE_DIM,
             ],
@@ -119,7 +120,12 @@ class TranslateMirrorGrid(ParallelTranslateGrid):
 
 
 class TranslateGridAreas(ParallelTranslateGrid):
-    def __init__(self, rank_grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        rank_grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(rank_grids, namelist, stencil_factory)
         self.max_error = 1e-10
         self.near_zero = 3e-14
@@ -131,77 +137,77 @@ class TranslateGridAreas(ParallelTranslateGrid):
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
         },
         "agrid": {
             "name": "agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
             "units": "radians",
         },
         "area": {
             "name": "area",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m^2",
         },
         "area_c": {
             "name": "area_cgrid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m^2",
         },
         "dxa": {
             "name": "dx_agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dya": {
             "name": "dy_agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dxc": {
             "name": "dx_cgrid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dyc": {
             "name": "dy_cgrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m",
         },
     }
     outputs = {
         "area": {
             "name": "area",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m^2",
         },
         "area_c": {
             "name": "area_cgrid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m^2",
         },
         "dxa": {
             "name": "dx_agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dya": {
             "name": "dy_agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dxc": {
             "name": "dx_cgrid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dyc": {
             "name": "dy_cgrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m",
         },
     }
@@ -232,8 +238,8 @@ class TranslateGridGrid(ParallelTranslateGrid):
         "grid_global": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
                 MetricTerms.TILE_DIM,
             ],
@@ -244,15 +250,20 @@ class TranslateGridGrid(ParallelTranslateGrid):
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
         },
     }
 
-    def __init__(self, grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 1.0e-13
         self.near_zero = 1e-14
@@ -277,7 +288,12 @@ class TranslateGridGrid(ParallelTranslateGrid):
 
 
 class TranslateDxDy(ParallelTranslateGrid):
-    def __init__(self, rank_grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        rank_grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(rank_grids, namelist, stencil_factory)
         self.max_error = 3e-14
         self.stencil_factory = stencil_factory
@@ -287,8 +303,8 @@ class TranslateDxDy(ParallelTranslateGrid):
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
@@ -297,12 +313,12 @@ class TranslateDxDy(ParallelTranslateGrid):
     outputs = {
         "dx": {
             "name": "dx",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m",
         },
         "dy": {
             "name": "dy",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
     }
@@ -326,7 +342,12 @@ class TranslateDxDy(ParallelTranslateGrid):
 
 
 class TranslateAGrid(ParallelTranslateGrid):
-    def __init__(self, rank_grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        rank_grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(rank_grids, namelist, stencil_factory)
         self.max_error = 1e-13
         self.namelist = namelist
@@ -335,14 +356,14 @@ class TranslateAGrid(ParallelTranslateGrid):
     inputs = {
         "agrid": {
             "name": "agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
             "units": "radians",
         },
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
@@ -351,14 +372,14 @@ class TranslateAGrid(ParallelTranslateGrid):
     outputs = {
         "agrid": {
             "name": "agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
             "units": "radians",
         },
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
@@ -416,60 +437,65 @@ class TranslateInitGrid(ParallelTranslateGrid):
         "gridvar": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
         },
         "agrid": {
             "name": "agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
             "units": "radians",
         },
         "area": {
             "name": "area",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m^2",
         },
         "area_c": {
             "name": "area_cgrid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m^2",
         },
         "dx": {
             "name": "dx",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m",
         },
         "dy": {
             "name": "dy",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dxc": {
             "name": "dx_cgrid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dyc": {
             "name": "dy_cgrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m",
         },
         "dxa": {
             "name": "dx_agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dya": {
             "name": "dy_agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m",
         },
     }
 
-    def __init__(self, grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 3e-12
         self.near_zero = 3e-14
@@ -511,12 +537,12 @@ class TranslateSetEta(ParallelTranslateGrid):
         },
         "ak": {
             "name": "ak",
-            "dims": [fv3util.Z_INTERFACE_DIM],
+            "dims": [pace.util.Z_INTERFACE_DIM],
             "units": "mb",
         },
         "bk": {
             "name": "bk",
-            "dims": [fv3util.Z_INTERFACE_DIM],
+            "dims": [pace.util.Z_INTERFACE_DIM],
             "units": "",
         },
     }
@@ -533,12 +559,12 @@ class TranslateSetEta(ParallelTranslateGrid):
         },
         "ak": {
             "name": "ak",
-            "dims": [fv3util.Z_INTERFACE_DIM],
+            "dims": [pace.util.Z_INTERFACE_DIM],
             "units": "mb",
         },
         "bk": {
             "name": "bk",
-            "dims": [fv3util.Z_INTERFACE_DIM],
+            "dims": [pace.util.Z_INTERFACE_DIM],
             "units": "",
         },
     }
@@ -568,7 +594,12 @@ class TranslateSetEta(ParallelTranslateGrid):
 
 
 class TranslateUtilVectors(ParallelTranslateGrid):
-    def __init__(self, grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 3e-12
         self.near_zero = 1e-13
@@ -613,77 +644,109 @@ class TranslateUtilVectors(ParallelTranslateGrid):
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
         },
         "agrid": {
             "name": "agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
             "units": "radians",
         },
         "ec1": {
             "name": "ec1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ec2": {
             "name": "ec2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ew1": {
             "name": "ew1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_DIM,
+            ],
             "units": "",
         },
         "ew2": {
             "name": "ew2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_DIM,
+            ],
             "units": "",
         },
         "es1": {
             "name": "es1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_DIM,
+                pace.util.Y_INTERFACE_DIM,
+            ],
             "units": "",
         },
         "es2": {
             "name": "es2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_DIM,
+                pace.util.Y_INTERFACE_DIM,
+            ],
             "units": "",
         },
     }
     outputs: Dict[str, Any] = {
         "ec1": {
             "name": "ec1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ec2": {
             "name": "ec2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ew1": {
             "name": "ew1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_DIM,
+            ],
             "units": "",
         },
         "ew2": {
             "name": "ew2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_DIM,
+            ],
             "units": "",
         },
         "es1": {
             "name": "es1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_DIM,
+                pace.util.Y_INTERFACE_DIM,
+            ],
             "units": "",
         },
         "es2": {
             "name": "es2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_DIM,
+                pace.util.Y_INTERFACE_DIM,
+            ],
             "units": "",
         },
     }
@@ -708,7 +771,12 @@ class TranslateUtilVectors(ParallelTranslateGrid):
 
 
 class TranslateTrigSg(ParallelTranslateGrid):
-    def __init__(self, grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 2.5e-10
         self.near_zero = 1e-14
@@ -744,207 +812,207 @@ class TranslateTrigSg(ParallelTranslateGrid):
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "",
         },
         "agrid": {
             "name": "agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
             "units": "radians",
         },
         "cos_sg1": {
             "name": "cos_sg1",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg1": {
             "name": "sin_sg1",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg2": {
             "name": "cos_sg2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg2": {
             "name": "sin_sg2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg3": {
             "name": "cos_sg3",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg3": {
             "name": "sin_sg3",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg4": {
             "name": "cos_sg4",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg4": {
             "name": "sin_sg4",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg5": {
             "name": "cos_sg5",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg5": {
             "name": "sin_sg5",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg6": {
             "name": "cos_sg6",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg6": {
             "name": "sin_sg6",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg7": {
             "name": "cos_sg7",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg7": {
             "name": "sin_sg7",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg8": {
             "name": "cos_sg8",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg8": {
             "name": "sin_sg8",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg9": {
             "name": "cos_sg9",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg9": {
             "name": "sin_sg9",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ec1": {
             "name": "ec1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ec2": {
             "name": "ec2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
     }
     outputs: Dict[str, Any] = {
         "cos_sg1": {
             "name": "cos_sg1",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg1": {
             "name": "sin_sg1",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg2": {
             "name": "cos_sg2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg2": {
             "name": "sin_sg2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg3": {
             "name": "cos_sg3",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg3": {
             "name": "sin_sg3",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg4": {
             "name": "cos_sg4",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg4": {
             "name": "sin_sg4",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg5": {
             "name": "cos_sg5",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg5": {
             "name": "sin_sg5",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg6": {
             "name": "cos_sg6",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg6": {
             "name": "sin_sg6",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg7": {
             "name": "cos_sg7",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg7": {
             "name": "sin_sg7",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg8": {
             "name": "cos_sg8",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg8": {
             "name": "sin_sg8",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg9": {
             "name": "cos_sg9",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg9": {
             "name": "sin_sg9",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
     }
@@ -975,7 +1043,12 @@ class TranslateAAMCorrection(ParallelTranslateGrid):
     # c48 and c128 with large relative errors, investigate!
     # these values are super tiny, so ignore_near_zero
     # will eliminate most points getting tested.
-    def __init__(self, rank_grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        rank_grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(rank_grids, namelist, stencil_factory)
         self.max_error = 1e-14
         self.near_zero = 1e-14
@@ -987,21 +1060,21 @@ class TranslateAAMCorrection(ParallelTranslateGrid):
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
         },
         "l2c_v": {
             "name": "l2c_v",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 0,
         },
         "l2c_u": {
             "name": "l2c_u",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
@@ -1009,13 +1082,13 @@ class TranslateAAMCorrection(ParallelTranslateGrid):
     outputs: Dict[str, Any] = {
         "l2c_v": {
             "name": "l2c_v",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 0,
         },
         "l2c_u": {
             "name": "l2c_u",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
@@ -1040,7 +1113,12 @@ class TranslateAAMCorrection(ParallelTranslateGrid):
 
 
 class TranslateDerivedTrig(ParallelTranslateGrid):
-    def __init__(self, grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 8.5e-14
         self.near_zero = 3e-14
@@ -1062,108 +1140,108 @@ class TranslateDerivedTrig(ParallelTranslateGrid):
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
         },
         "cos_sg1": {
             "name": "cos_sg1",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg1": {
             "name": "sin_sg1",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg2": {
             "name": "cos_sg2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg2": {
             "name": "sin_sg2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg3": {
             "name": "cos_sg3",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg3": {
             "name": "sin_sg3",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg4": {
             "name": "cos_sg4",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg4": {
             "name": "sin_sg4",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg5": {
             "name": "cos_sg5",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg5": {
             "name": "sin_sg5",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg6": {
             "name": "cos_sg6",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg6": {
             "name": "sin_sg6",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg7": {
             "name": "cos_sg7",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg7": {
             "name": "sin_sg7",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg8": {
             "name": "cos_sg8",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg8": {
             "name": "sin_sg8",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg9": {
             "name": "cos_sg9",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg9": {
             "name": "sin_sg9",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ee1": {
             "name": "ee1",
             "dims": [
                 MetricTerms.CARTESIAN_DIM,
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
             ],
             "units": "",
         },
@@ -1171,61 +1249,65 @@ class TranslateDerivedTrig(ParallelTranslateGrid):
             "name": "ee2",
             "dims": [
                 MetricTerms.CARTESIAN_DIM,
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
             ],
             "units": "",
         },
         "cosa_u": {
             "name": "cosa_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cosa_v": {
             "name": "cosa_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "cosa_s": {
             "name": "cosa_s",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sina_u": {
             "name": "sina_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sina_v": {
             "name": "sina_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "rsin_u": {
             "name": "rsin_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "rsin_v": {
             "name": "rsin_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "rsina": {
             "name": "rsina",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
-        "rsin2": {"name": "rsin2", "dims": [fv3util.X_DIM, fv3util.Y_DIM], "units": ""},
+        "rsin2": {
+            "name": "rsin2",
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
+            "units": "",
+        },
         "cosa": {
             "name": "cosa",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "sina": {
             "name": "sina",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
     }
@@ -1234,8 +1316,8 @@ class TranslateDerivedTrig(ParallelTranslateGrid):
             "name": "ee1",
             "dims": [
                 MetricTerms.CARTESIAN_DIM,
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
             ],
             "units": "",
         },
@@ -1243,61 +1325,65 @@ class TranslateDerivedTrig(ParallelTranslateGrid):
             "name": "ee2",
             "dims": [
                 MetricTerms.CARTESIAN_DIM,
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
             ],
             "units": "",
         },
         "cosa_u": {
             "name": "cosa_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cosa_v": {
             "name": "cosa_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "cosa_s": {
             "name": "cosa_s",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sina_u": {
             "name": "sina_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sina_v": {
             "name": "sina_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "rsin_u": {
             "name": "rsin_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "rsin_v": {
             "name": "rsin_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "rsina": {
             "name": "rsina",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
-        "rsin2": {"name": "rsin2", "dims": [fv3util.X_DIM, fv3util.Y_DIM], "units": ""},
+        "rsin2": {
+            "name": "rsin2",
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
+            "units": "",
+        },
         "cosa": {
             "name": "cosa",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "sina": {
             "name": "sina",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
     }
@@ -1340,7 +1426,12 @@ class TranslateDerivedTrig(ParallelTranslateGrid):
 
 
 class TranslateDivgDel6(ParallelTranslateGrid):
-    def __init__(self, rank_grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        rank_grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(rank_grids, namelist, stencil_factory)
         self.max_error = 4e-14
         self.stencil_factory = stencil_factory
@@ -1349,94 +1440,94 @@ class TranslateDivgDel6(ParallelTranslateGrid):
     inputs: Dict[str, Any] = {
         "sin_sg1": {
             "name": "sin_sg1",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg2": {
             "name": "sin_sg2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg3": {
             "name": "sin_sg3",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg4": {
             "name": "sin_sg4",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sina_u": {
             "name": "sina_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sina_v": {
             "name": "sina_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "dx": {
             "name": "dx",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m",
         },
         "dy": {
             "name": "dy",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dxc": {
             "name": "dx_cgrid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dyc": {
             "name": "dy_cgrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "divg_u": {
             "name": "divg_u",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "divg_v": {
             "name": "divg_v",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "del6_u": {
             "name": "del6_u",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "del6_v": {
             "name": "del6_v",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
     }
     outputs: Dict[str, Any] = {
         "divg_u": {
             "name": "divg_u",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "divg_v": {
             "name": "divg_v",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "del6_u": {
             "name": "del6_u",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "del6_v": {
             "name": "del6_v",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
     }
@@ -1470,7 +1561,12 @@ class TranslateDivgDel6(ParallelTranslateGrid):
 
 
 class TranslateInitCubedtoLatLon(ParallelTranslateGrid):
-    def __init__(self, grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 3.0e-14
         self._base.in_vars["data_vars"] = {
@@ -1489,83 +1585,83 @@ class TranslateInitCubedtoLatLon(ParallelTranslateGrid):
     inputs: Dict[str, Any] = {
         "agrid": {
             "name": "agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
             "units": "radians",
         },
         "ec1": {
             "name": "ec1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ec2": {
             "name": "ec2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg5": {
             "name": "sin_sg5",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
     }
     outputs: Dict[str, Any] = {
         "vlon": {
             "name": "vlon",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.CARTESIAN_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.CARTESIAN_DIM],
             "units": "",
             "n_halo": 2,
         },
         "vlat": {
             "name": "vlat",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.CARTESIAN_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.CARTESIAN_DIM],
             "units": "",
             "n_halo": 2,
         },
         "z11": {
             "name": "z11",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "z12": {
             "name": "z12",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "z21": {
             "name": "z21",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "z22": {
             "name": "z22",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "a11": {
             "name": "a11",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "a12": {
             "name": "a12",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "a21": {
             "name": "a21",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "a22": {
             "name": "a22",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
@@ -1593,7 +1689,12 @@ class TranslateInitCubedtoLatLon(ParallelTranslateGrid):
 
 
 class TranslateEdgeFactors(ParallelTranslateGrid):
-    def __init__(self, rank_grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        rank_grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(rank_grids, namelist, stencil_factory)
         self.max_error = 3e-13
         self.stencil_factory = stencil_factory
@@ -1603,105 +1704,105 @@ class TranslateEdgeFactors(ParallelTranslateGrid):
         "grid": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
         },
         "agrid": {
             "name": "agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
             "units": "radians",
         },
         "edge_s": {
             "name": "edge_s",
-            "dims": [fv3util.X_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
         "edge_n": {
             "name": "edge_n",
-            "dims": [fv3util.X_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
         "edge_e": {
             "name": "edge_e",
-            "dims": [fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
         "edge_w": {
             "name": "edge_w",
-            "dims": [fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
         "edge_vect_s": {
             "name": "edge_vect_s",
-            "dims": [fv3util.X_DIM],
+            "dims": [pace.util.X_DIM],
             "units": "",
         },
         "edge_vect_n": {
             "name": "edge_vect_n",
-            "dims": [fv3util.X_DIM],
+            "dims": [pace.util.X_DIM],
             "units": "",
         },
         "edge_vect_e": {
             "name": "edge_vect_e",
-            "dims": [fv3util.Y_DIM],
+            "dims": [pace.util.Y_DIM],
             "units": "",
         },
         "edge_vect_w": {
             "name": "edge_vect_w",
-            "dims": [fv3util.Y_DIM],
+            "dims": [pace.util.Y_DIM],
             "units": "",
         },
     }
     outputs: Dict[str, Any] = {
         "edge_s": {
             "name": "edge_s",
-            "dims": [fv3util.X_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
         "edge_n": {
             "name": "edge_n",
-            "dims": [fv3util.X_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
         "edge_e": {
             "name": "edge_e",
-            "dims": [fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
         "edge_w": {
             "name": "edge_w",
-            "dims": [fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
         "edge_vect_s": {
             "name": "edge_vect_s",
-            "dims": [fv3util.X_DIM],
+            "dims": [pace.util.X_DIM],
             "units": "",
         },
         "edge_vect_n": {
             "name": "edge_vect_n",
-            "dims": [fv3util.X_DIM],
+            "dims": [pace.util.X_DIM],
             "units": "",
         },
         "edge_vect_e": {
             "name": "edge_vect_e",
-            "dims": [fv3util.Y_DIM],
+            "dims": [pace.util.Y_DIM],
             "units": "",
         },
         "edge_vect_w": {
             "name": "edge_vect_w",
-            "dims": [fv3util.Y_DIM],
+            "dims": [pace.util.Y_DIM],
             "units": "",
         },
     }
@@ -1730,7 +1831,12 @@ class TranslateEdgeFactors(ParallelTranslateGrid):
 
 
 class TranslateInitGridUtils(ParallelTranslateGrid):
-    def __init__(self, grids, namelist, stencil_factory):
+    def __init__(
+        self,
+        grids,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grids, namelist, stencil_factory)
         self.max_error = 2.5e-10
         self.near_zero = 5e-14
@@ -1793,55 +1899,55 @@ class TranslateInitGridUtils(ParallelTranslateGrid):
         "gridvar": {
             "name": "grid",
             "dims": [
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
                 MetricTerms.LON_OR_LAT_DIM,
             ],
             "units": "radians",
         },
         "agrid": {
             "name": "agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.LON_OR_LAT_DIM],
             "units": "radians",
         },
         "area": {
             "name": "area",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m^2",
         },
         "area_c": {
             "name": "area_cgrid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m^2",
         },
         "dx": {
             "name": "dx",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m",
         },
         "dy": {
             "name": "dy",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dxc": {
             "name": "dx_cgrid",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dyc": {
             "name": "dy_cgrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "m",
         },
         "dxa": {
             "name": "dx_agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "dya": {
             "name": "dy_agrid",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "m",
         },
         "npz": {
@@ -1863,143 +1969,159 @@ class TranslateInitGridUtils(ParallelTranslateGrid):
         },
         "ak": {
             "name": "ak",
-            "dims": [fv3util.Z_INTERFACE_DIM],
+            "dims": [pace.util.Z_INTERFACE_DIM],
             "units": "mb",
         },
         "bk": {
             "name": "bk",
-            "dims": [fv3util.Z_INTERFACE_DIM],
+            "dims": [pace.util.Z_INTERFACE_DIM],
             "units": "",
         },
         "ec1": {
             "name": "ec1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ec2": {
             "name": "ec2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [MetricTerms.CARTESIAN_DIM, pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "ew1": {
             "name": "ew1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_DIM,
+            ],
             "units": "",
         },
         "ew2": {
             "name": "ew2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_DIM,
+            ],
             "units": "",
         },
         "es1": {
             "name": "es1",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_DIM,
+                pace.util.Y_INTERFACE_DIM,
+            ],
             "units": "",
         },
         "es2": {
             "name": "es2",
-            "dims": [MetricTerms.CARTESIAN_DIM, fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [
+                MetricTerms.CARTESIAN_DIM,
+                pace.util.X_DIM,
+                pace.util.Y_INTERFACE_DIM,
+            ],
             "units": "",
         },
         "cos_sg1": {
             "name": "cos_sg1",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg1": {
             "name": "sin_sg1",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg2": {
             "name": "cos_sg2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg2": {
             "name": "sin_sg2",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg3": {
             "name": "cos_sg3",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg3": {
             "name": "sin_sg3",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg4": {
             "name": "cos_sg4",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg4": {
             "name": "sin_sg4",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg5": {
             "name": "cos_sg5",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg5": {
             "name": "sin_sg5",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg6": {
             "name": "cos_sg6",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg6": {
             "name": "sin_sg6",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg7": {
             "name": "cos_sg7",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg7": {
             "name": "sin_sg7",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg8": {
             "name": "cos_sg8",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg8": {
             "name": "sin_sg8",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cos_sg9": {
             "name": "cos_sg9",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sin_sg9": {
             "name": "sin_sg9",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "l2c_v": {
             "name": "l2c_v",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 0,
         },
         "l2c_u": {
             "name": "l2c_u",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
@@ -2007,8 +2129,8 @@ class TranslateInitGridUtils(ParallelTranslateGrid):
             "name": "ee1",
             "dims": [
                 MetricTerms.CARTESIAN_DIM,
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
             ],
             "units": "",
         },
@@ -2016,161 +2138,165 @@ class TranslateInitGridUtils(ParallelTranslateGrid):
             "name": "ee2",
             "dims": [
                 MetricTerms.CARTESIAN_DIM,
-                fv3util.X_INTERFACE_DIM,
-                fv3util.Y_INTERFACE_DIM,
+                pace.util.X_INTERFACE_DIM,
+                pace.util.Y_INTERFACE_DIM,
             ],
             "units": "",
         },
         "cosa_u": {
             "name": "cosa_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "cosa_v": {
             "name": "cosa_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "cosa_s": {
             "name": "cosa_s",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sina_u": {
             "name": "sina_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "sina_v": {
             "name": "sina_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "rsin_u": {
             "name": "rsin_u",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "rsin_v": {
             "name": "rsin_v",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "rsina": {
             "name": "rsina",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
             "n_halo": 0,
         },
-        "rsin2": {"name": "rsin2", "dims": [fv3util.X_DIM, fv3util.Y_DIM], "units": ""},
+        "rsin2": {
+            "name": "rsin2",
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
+            "units": "",
+        },
         "cosa": {
             "name": "cosa",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "sina": {
             "name": "sina",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "divg_u": {
             "name": "divg_u",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "divg_v": {
             "name": "divg_v",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "del6_u": {
             "name": "del6_u",
-            "dims": [fv3util.X_DIM, fv3util.Y_INTERFACE_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_INTERFACE_DIM],
             "units": "",
         },
         "del6_v": {
             "name": "del6_v",
-            "dims": [fv3util.X_INTERFACE_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_INTERFACE_DIM, pace.util.Y_DIM],
             "units": "",
         },
         "vlon": {
             "name": "vlon",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.CARTESIAN_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.CARTESIAN_DIM],
             "units": "",
             "n_halo": 2,
         },
         "vlat": {
             "name": "vlat",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM, MetricTerms.CARTESIAN_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM, MetricTerms.CARTESIAN_DIM],
             "units": "",
             "n_halo": 2,
         },
         "z11": {
             "name": "z11",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "z12": {
             "name": "z12",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "z21": {
             "name": "z21",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "z22": {
             "name": "z22",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "a11": {
             "name": "a11",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "a12": {
             "name": "a12",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "a21": {
             "name": "a21",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "a22": {
             "name": "a22",
-            "dims": [fv3util.X_DIM, fv3util.Y_DIM],
+            "dims": [pace.util.X_DIM, pace.util.Y_DIM],
             "units": "",
             "n_halo": 1,
         },
         "edge_vect_s": {
             "name": "edge_vect_s",
-            "dims": [fv3util.X_DIM],
+            "dims": [pace.util.X_DIM],
             "units": "",
         },
         "edge_vect_n": {
             "name": "edge_vect_n",
-            "dims": [fv3util.X_DIM],
+            "dims": [pace.util.X_DIM],
             "units": "",
         },
         "edge_vect_e": {
             "name": "edge_vect_e",
-            "dims": [fv3util.Y_DIM],
+            "dims": [pace.util.Y_DIM],
             "units": "",
         },
         "edge_vect_w": {
             "name": "edge_vect_w",
-            "dims": [fv3util.Y_DIM],
+            "dims": [pace.util.Y_DIM],
             "units": "",
         },
         "da_min": {

--- a/fv3core/tests/savepoint/translate/translate_haloupdate.py
+++ b/fv3core/tests/savepoint/translate/translate_haloupdate.py
@@ -1,5 +1,7 @@
 import logging
 
+import pace.dsl
+import pace.util
 import pace.util as fv3util
 from pace.dsl import gt4py_utils as utils
 from pace.stencils.testing import ParallelTranslate
@@ -29,7 +31,12 @@ class TranslateHaloUpdate(ParallelTranslate):
     }
     halo_update_varname = "air_temperature"
 
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
 
     def compute_parallel(self, inputs, communicator):
@@ -134,7 +141,12 @@ class TranslateHaloVectorUpdate(ParallelTranslate):
         },
     }
 
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super(TranslateHaloVectorUpdate, self).__init__(grid, namelist, stencil_factory)
 
     def compute_parallel(self, inputs, communicator):
@@ -198,7 +210,12 @@ class TranslateMPPBoundaryAdjust(ParallelTranslate):
         },
     }
 
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super(TranslateMPPBoundaryAdjust, self).__init__(
             grid, namelist, stencil_factory
         )

--- a/fv3core/tests/savepoint/translate/translate_init_case.py
+++ b/fv3core/tests/savepoint/translate/translate_init_case.py
@@ -6,7 +6,9 @@ import pytest
 import fv3core.initialization.baroclinic as baroclinic_init
 import fv3core.initialization.baroclinic_jablonowski_williamson as jablo_init
 import fv3core.stencils.fv_dynamics as fv_dynamics
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 import pace.util as fv3util
 from pace.stencils.testing import (
     ParallelTranslateBaseSlicing,
@@ -110,7 +112,12 @@ class TranslateInitCase(ParallelTranslateBaseSlicing):
         },
     }
 
-    def __init__(self, grid_list, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid_list,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid_list, namelist, stencil_factory)
         grid = grid_list[0]
         self._base.in_vars["data_vars"] = {}
@@ -228,7 +235,12 @@ def make_sliced_inputs_dict(inputs, slice_2d):
 
 
 class TranslateInitPreJab(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {"ak": {}, "bk": {}, "delp": {}}
         self.in_vars["parameters"] = ["ptop"]
@@ -282,7 +294,12 @@ class TranslateInitPreJab(TranslateDycoreFortranData2Py):
 
 
 class TranslateJablonowskiBaroclinic(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "delp": {},
@@ -359,7 +376,12 @@ class TranslateJablonowskiBaroclinic(TranslateDycoreFortranData2Py):
 
 
 class TranslatePVarAuxiliaryPressureVars(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "delp": {},

--- a/fv3core/tests/savepoint/translate/translate_last_step.py
+++ b/fv3core/tests/savepoint/translate/translate_last_step.py
@@ -1,9 +1,16 @@
 import fv3core.stencils.moist_cv as moist_cv
+import pace.dsl
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateLastStep(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.compute_func = stencil_factory.from_origin_domain(
             moist_cv.moist_pt_last_step,

--- a/fv3core/tests/savepoint/translate/translate_map1_ppm_2d.py
+++ b/fv3core/tests/savepoint/translate/translate_map1_ppm_2d.py
@@ -1,6 +1,10 @@
+from typing import Any, Dict
+
 import numpy as np
 
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from fv3core.testing import MapSingleFactory
 from pace.stencils.testing import (
     TranslateDycoreFortranData2Py,
@@ -29,7 +33,12 @@ class TranslateSingleJ(TranslateDycoreFortranData2Py):
 
 
 class TranslateMap1_PPM_2d(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.compute_func = MapSingleFactory(stencil_factory)
         self.in_vars["data_vars"] = {
@@ -39,7 +48,7 @@ class TranslateMap1_PPM_2d(TranslateDycoreFortranData2Py):
             "qs": {"serialname": "ws_1d", "kstart": grid.is_, "axis": 0},
         }
         self.in_vars["parameters"] = ["j_2d", "i1", "i2", "mode", "kord"]
-        self.out_vars = {"var_inout": {}}
+        self.out_vars: Dict[str, Any] = {"var_inout": {}}
         self.max_error = 5e-13
         self.write_vars = ["qs"]
         self.nj = self.maxshape[1]
@@ -99,7 +108,12 @@ class TranslateMap1_PPM_2d(TranslateDycoreFortranData2Py):
 
 
 class TranslateMap1_PPM_2d_3(TranslateMap1_PPM_2d):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"]["pe1"]["serialname"] = "pe1_2"
         self.in_vars["data_vars"]["pe2"]["serialname"] = "pe2_2"
@@ -114,7 +128,12 @@ class TranslateMap1_PPM_2d_3(TranslateMap1_PPM_2d):
 
 
 class TranslateMap1_PPM_2d_2(TranslateMap1_PPM_2d):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"]["pe1"]["serialname"] = "pe1_2"
         self.in_vars["data_vars"]["pe2"]["serialname"] = "pe2_2"

--- a/fv3core/tests/savepoint/translate/translate_map_scalar_2d.py
+++ b/fv3core/tests/savepoint/translate/translate_map_scalar_2d.py
@@ -1,4 +1,8 @@
+from typing import Any, Dict
+
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from fv3core.testing import MapSingleFactory
 from pace.stencils.testing import (
     TranslateDycoreFortranData2Py,
@@ -8,7 +12,12 @@ from pace.stencils.testing import (
 
 
 class TranslateMapScalar_2d(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.compute_func = MapSingleFactory(stencil_factory)
         self.in_vars["data_vars"] = {
@@ -29,7 +38,7 @@ class TranslateMapScalar_2d(TranslateDycoreFortranData2Py):
             "qs": {"serialname": "gz1d", "kstart": 0, "axis": 0},
         }
         self.in_vars["parameters"] = ["j_2d", "mode"]
-        self.out_vars = {"pt": {}}  # "jstart": grid.js, "jend": grid.js
+        self.out_vars: Dict[str, Any] = {"pt": {}}  # "jstart": grid.js, "jend": grid.js
         self.is_ = grid.is_
         self.ie = grid.ie
         self.write_vars = ["qs"]

--- a/fv3core/tests/savepoint/translate/translate_mapn_tracer_2d.py
+++ b/fv3core/tests/savepoint/translate/translate_mapn_tracer_2d.py
@@ -1,4 +1,6 @@
 import fv3core.stencils.mapn_tracer as MapN_Tracer
+import pace.dsl
+import pace.util
 from pace.stencils.testing import (
     TranslateDycoreFortranData2Py,
     TranslateGrid,
@@ -7,7 +9,12 @@ from pace.stencils.testing import (
 
 
 class TranslateMapN_Tracer_2d(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "pe1": {"istart": grid.is_, "iend": grid.ie - 2, "axis": 1},

--- a/fv3core/tests/savepoint/translate/translate_moistcvpluspkz_2d.py
+++ b/fv3core/tests/savepoint/translate/translate_moistcvpluspkz_2d.py
@@ -1,9 +1,16 @@
 import fv3core.stencils.moist_cv as moist_cv
+import pace.dsl
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py, pad_field_in_j
 
 
 class TranslateMoistCVPlusPkz_2d(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.stencil_factory = stencil_factory
         self.compute_func = self.stencil_factory.from_origin_domain(

--- a/fv3core/tests/savepoint/translate/translate_moistcvpluspt_2d.py
+++ b/fv3core/tests/savepoint/translate/translate_moistcvpluspt_2d.py
@@ -1,6 +1,8 @@
 from gt4py.gtscript import PARALLEL, computation, interval
 
 import fv3core.stencils.moist_cv as moist_cv
+import pace.dsl
+import pace.util
 from pace.dsl.typing import FloatField
 from pace.stencils.testing import TranslateDycoreFortranData2Py, pad_field_in_j
 
@@ -41,7 +43,12 @@ def moist_pt(
 
 
 class TranslateMoistCVPlusPt_2d(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.stencil_factory = stencil_factory
         self.compute_func = self.stencil_factory.from_origin_domain(

--- a/fv3core/tests/savepoint/translate/translate_neg_adj3.py
+++ b/fv3core/tests/savepoint/translate/translate_neg_adj3.py
@@ -1,10 +1,19 @@
+from typing import Any, Dict
+
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from fv3core.stencils.neg_adj3 import AdjustNegativeTracerMixingRatio
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateNeg_Adj3(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "qvapor": {},
@@ -20,7 +29,7 @@ class TranslateNeg_Adj3(TranslateDycoreFortranData2Py):
             "peln": {"istart": grid.is_, "jstart": grid.js, "kaxis": 1},
         }
         self.in_vars["parameters"] = []
-        self.out_vars = {
+        self.out_vars: Dict[str, Any] = {
             "qvapor": {},
             "qliquid": {},
             "qice": {},

--- a/fv3core/tests/savepoint/translate/translate_nh_p_grad.py
+++ b/fv3core/tests/savepoint/translate/translate_nh_p_grad.py
@@ -1,9 +1,16 @@
 import fv3core.stencils.nh_p_grad as NH_P_Grad
+import pace.dsl
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateNH_P_Grad(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "u": {},

--- a/fv3core/tests/savepoint/translate/translate_pe_halo.py
+++ b/fv3core/tests/savepoint/translate/translate_pe_halo.py
@@ -1,9 +1,16 @@
+import pace.dsl
+import pace.util
 from fv3core.stencils import pe_halo
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslatePE_Halo(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
 
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {

--- a/fv3core/tests/savepoint/translate/translate_pk3_halo.py
+++ b/fv3core/tests/savepoint/translate/translate_pk3_halo.py
@@ -1,9 +1,16 @@
+import pace.dsl
+import pace.util
 from fv3core.stencils.pk3_halo import PK3Halo
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslatePK3_Halo(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.stencil_factory = stencil_factory
         self.compute_func = PK3Halo(self.stencil_factory)

--- a/fv3core/tests/savepoint/translate/translate_pressureadjustedtemperature_nonhydrostatic.py
+++ b/fv3core/tests/savepoint/translate/translate_pressureadjustedtemperature_nonhydrostatic.py
@@ -1,3 +1,6 @@
+import fv3core
+import pace.dsl
+import pace.util
 from fv3core.stencils import temperature_adjust
 from fv3core.stencils.dyn_core import get_nk_heat_dissipation
 from pace.stencils.testing import TranslateDycoreFortranData2Py
@@ -6,11 +9,17 @@ from pace.stencils.testing import TranslateDycoreFortranData2Py
 class TranslatePressureAdjustedTemperature_NonHydrostatic(
     TranslateDycoreFortranData2Py
 ):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.namelist = namelist
+        dycore_config = fv3core.DynamicalCoreConfig.from_namelist(namelist)
         n_adj = get_nk_heat_dissipation(
-            config=self.namelist.d_grid_shallow_water,
+            config=dycore_config.d_grid_shallow_water,
             npz=grid.grid_indexing.domain[2],
         )
         self.compute_func = stencil_factory.from_origin_domain(

--- a/fv3core/tests/savepoint/translate/translate_qsinit.py
+++ b/fv3core/tests/savepoint/translate/translate_qsinit.py
@@ -1,12 +1,19 @@
 import numpy as np
 
 import fv3core.stencils.saturation_adjustment as satadjust
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateQSInit(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "table": {},

--- a/fv3core/tests/savepoint/translate/translate_ray_fast.py
+++ b/fv3core/tests/savepoint/translate/translate_ray_fast.py
@@ -1,9 +1,16 @@
+import pace.dsl
+import pace.util
 from fv3core.stencils.ray_fast import RayleighDamping
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateRay_Fast(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.compute_func = RayleighDamping(
             stencil_factory,

--- a/fv3core/tests/savepoint/translate/translate_remap_profile_2d.py
+++ b/fv3core/tests/savepoint/translate/translate_remap_profile_2d.py
@@ -1,12 +1,19 @@
 import numpy as np
 
 import fv3core.stencils.remap_profile as profile
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateCS_Profile_2d(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "a4_1": {"serialname": "q4_1"},
@@ -80,7 +87,12 @@ class TranslateCS_Profile_2d(TranslateDycoreFortranData2Py):
 
 
 class TranslateCS_Profile_2d_2(TranslateCS_Profile_2d):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "qs": {"serialname": "qs_column_2", "kstart": 0, "kend": grid.npz},

--- a/fv3core/tests/savepoint/translate/translate_remapping.py
+++ b/fv3core/tests/savepoint/translate/translate_remapping.py
@@ -1,10 +1,17 @@
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from fv3core.stencils.remapping import LagrangianToEulerian
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateRemapping(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "tracers": {},

--- a/fv3core/tests/savepoint/translate/translate_remapping.py
+++ b/fv3core/tests/savepoint/translate/translate_remapping.py
@@ -1,6 +1,7 @@
 import pace.dsl
 import pace.dsl.gt4py_utils as utils
 import pace.util
+from fv3core import DynamicalCoreConfig
 from fv3core.stencils.remapping import LagrangianToEulerian
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
@@ -125,7 +126,7 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
         inputs["last_step"] = bool(inputs["last_step"])
         l_to_e_obj = LagrangianToEulerian(
             self.stencil_factory,
-            self.namelist.remapping,
+            DynamicalCoreConfig.from_namelist(self.namelist).remapping,
             self.grid.area_64,
             inputs["nq"],
             inputs["pfull"],

--- a/fv3core/tests/savepoint/translate/translate_riem_solver3.py
+++ b/fv3core/tests/savepoint/translate/translate_riem_solver3.py
@@ -1,10 +1,17 @@
 import fv3core._config as spec
+import pace.dsl
+import pace.util
 from fv3core.stencils.riem_solver3 import RiemannSolver3
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateRiem_Solver3(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.riemann_solver_3 = RiemannSolver3(
             stencil_factory,

--- a/fv3core/tests/savepoint/translate/translate_riem_solver_c.py
+++ b/fv3core/tests/savepoint/translate/translate_riem_solver_c.py
@@ -1,9 +1,16 @@
+import pace.dsl
+import pace.util
 from fv3core.stencils.riem_solver_c import RiemannSolverC
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateRiem_Solver_C(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.compute_func = RiemannSolverC(stencil_factory, namelist.p_fac)
         self.in_vars["data_vars"] = {

--- a/fv3core/tests/savepoint/translate/translate_satadjust3d.py
+++ b/fv3core/tests/savepoint/translate/translate_satadjust3d.py
@@ -1,9 +1,16 @@
+import pace.dsl
+import pace.util
 from fv3core.stencils.saturation_adjustment import SatAdjust3d
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateSatAdjust3d(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "te": {},

--- a/fv3core/tests/savepoint/translate/translate_satadjust3d.py
+++ b/fv3core/tests/savepoint/translate/translate_satadjust3d.py
@@ -1,5 +1,6 @@
 import pace.dsl
 import pace.util
+from fv3core import DynamicalCoreConfig
 from fv3core.stencils.saturation_adjustment import SatAdjust3d
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
@@ -68,7 +69,7 @@ class TranslateSatAdjust3d(TranslateDycoreFortranData2Py):
         inputs["fast_mp_consv"] = bool(inputs["fast_mp_consv"])
         satadjust3d_obj = SatAdjust3d(
             self.stencil_factory,
-            self.namelist.sat_adjust,
+            DynamicalCoreConfig.from_namelist(self.namelist).sat_adjust,
             self.grid.area_64,
             int(inputs["kmp"]),
         )

--- a/fv3core/tests/savepoint/translate/translate_tracer2d1l.py
+++ b/fv3core/tests/savepoint/translate/translate_tracer2d1l.py
@@ -3,7 +3,9 @@ import pytest
 import fv3core.stencils.fv_dynamics as fv_dynamics
 import fv3core.stencils.fvtp2d
 import fv3core.stencils.tracer_2d_1l
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 import pace.util as fv3util
 from pace.stencils.testing import ParallelTranslate
 
@@ -16,7 +18,12 @@ class TranslateTracer2D1L(ParallelTranslate):
         }
     }
 
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self._base.in_vars["data_vars"] = {
             "tracers": {},

--- a/fv3core/tests/savepoint/translate/translate_updatedzc.py
+++ b/fv3core/tests/savepoint/translate/translate_updatedzc.py
@@ -1,9 +1,16 @@
 import fv3core.stencils.updatedzc as updatedzc
+import pace.dsl
+import pace.util
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateUpdateDzC(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.stencil_factory = stencil_factory
         update_gz_on_c_grid = updatedzc.UpdateGeopotentialHeightOnCGrid(

--- a/fv3core/tests/savepoint/translate/translate_updatedzd.py
+++ b/fv3core/tests/savepoint/translate/translate_updatedzd.py
@@ -1,12 +1,19 @@
 import numpy as np
 
 import fv3core.stencils.updatedzd
+import pace.dsl
+import pace.util
 from fv3core.stencils import d_sw
 from pace.stencils.testing import TranslateDycoreFortranData2Py
 
 
 class TranslateUpdateDzD(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "dp0": {},  # column var

--- a/fv3core/tests/savepoint/translate/translate_xppm.py
+++ b/fv3core/tests/savepoint/translate/translate_xppm.py
@@ -1,10 +1,17 @@
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from fv3core.stencils import xppm
 from pace.stencils.testing import TranslateDycoreFortranData2Py, TranslateGrid
 
 
 class TranslateXPPM(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "q": {"serialname": "qx", "jstart": "jfirst"},
@@ -51,7 +58,12 @@ class TranslateXPPM(TranslateDycoreFortranData2Py):
 
 
 class TranslateXPPM_2(TranslateXPPM):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"]["q"]["serialname"] = "q"
         self.out_vars["xflux"]["serialname"] = "xflux_2"

--- a/fv3core/tests/savepoint/translate/translate_xtp_u.py
+++ b/fv3core/tests/savepoint/translate/translate_xtp_u.py
@@ -1,6 +1,8 @@
 from gt4py.gtscript import PARALLEL, computation, interval
 
 import fv3core.stencils.xtp_u as xtp_u
+import pace.dsl
+import pace.util
 from pace.dsl.stencil import StencilFactory
 from pace.dsl.typing import FloatField, FloatFieldIJ
 from pace.util.grid import GridData
@@ -73,7 +75,12 @@ class XTP_U:
 
 
 class TranslateXTP_U(TranslateYTP_V):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"]["u"] = {}
         self.in_vars["data_vars"]["c"]["serialname"] = "ub"

--- a/fv3core/tests/savepoint/translate/translate_yppm.py
+++ b/fv3core/tests/savepoint/translate/translate_yppm.py
@@ -1,10 +1,17 @@
+import pace.dsl
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from fv3core.stencils import yppm
 from pace.stencils.testing import TranslateDycoreFortranData2Py, TranslateGrid
 
 
 class TranslateYPPM(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"] = {
             "q": {"istart": "ifirst"},
@@ -52,7 +59,12 @@ class TranslateYPPM(TranslateDycoreFortranData2Py):
 
 
 class TranslateYPPM_2(TranslateYPPM):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         self.in_vars["data_vars"]["q"]["serialname"] = "q_2"
         self.out_vars["flux"]["serialname"] = "flux_2"

--- a/fv3core/tests/savepoint/translate/translate_ytp_v.py
+++ b/fv3core/tests/savepoint/translate/translate_ytp_v.py
@@ -1,6 +1,8 @@
 from gt4py.gtscript import PARALLEL, computation, interval
 
 import fv3core.stencils.ytp_v as ytp_v
+import pace.dsl
+import pace.util
 from pace.dsl.stencil import StencilFactory
 from pace.dsl.typing import FloatField, FloatFieldIJ
 from pace.stencils.testing import TranslateDycoreFortranData2Py
@@ -67,7 +69,12 @@ class YTP_V:
 
 
 class TranslateYTP_V(TranslateDycoreFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, namelist, stencil_factory)
         c_info = self.grid.compute_dict_buffer_2d()
         c_info["serialname"] = "vb"

--- a/stencils/pace/stencils/testing/translate_dycore.py
+++ b/stencils/pace/stencils/testing/translate_dycore.py
@@ -1,8 +1,15 @@
+import pace.dsl
+import pace.util
 from fv3core._config import DynamicalCoreConfig
 from pace.stencils.testing.translate import TranslateFortranData2Py
 
 
 class TranslateDycoreFortranData2Py(TranslateFortranData2Py):
-    def __init__(self, grid, namelist, stencil_factory):
+    def __init__(
+        self,
+        grid,
+        namelist: pace.util.Namelist,
+        stencil_factory: pace.dsl.StencilFactory,
+    ):
         super().__init__(grid, stencil_factory)
         self.namelist = DynamicalCoreConfig.from_namelist(namelist)


### PR DESCRIPTION
## Purpose

The dynamics and physics translate tests have gone partially out of sync, a big difference being that they use different configuration classes in their translate objects. This PR updates the dynamics translate tests so they use the more general-purpose Namelist configuration class.

## Infrastructure changes:

- This PR updates the dynamics translate tests so they use the more general-purpose Namelist configuration class.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes