### PR TITLE
Documentation/pace doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ cd ../
 $ make build
 ```
 
-For serial tests (these take a bit of time), there are two options: 
+For serial tests (these take a bit of time), there are two options:
 
 (1) To enter the container and run the dynamical core serial tests (main and savepoint tests):
 
@@ -57,7 +57,7 @@ For parallel tests:
 $ mpirun -np 6 python -m mpi4py -m pytest -v -s -m parallel --data_path=/fv3core/test_data/c12_6ranks_standard/ /fv3core/tests
 ```
 
-or 
+or
 
 ```shell
 $ DEV=y make savepoint_tests_mpi
@@ -98,7 +98,7 @@ For parallel tests use:
 $ mpirun -np 6 python -m mpi4py -m pytest -v -s -m parallel --data_path=/test_data/8.1.0/c12_6ranks_baroclinic_dycore_microphysics/physics/ /fv3gfs-physics/tests --threshold_overrides_file=/fv3gfs-physics/tests/savepoint/translate/overrides/baroclinic.yaml
 ```
 
-or 
+or
 
 ```shell
 $ DEV=y make physics_savepoint_tests_mpi

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For serial tests (these take a bit of time), there are two options:
 
 ```shell
 $ make dev
-$ pytest -v -s --data_path=/fv3core/test_data/8.1.0/c12_6ranks_standard/dycore/ /fv3core/tests
+$ pytest -v -s --data_path=/fv3core/test_data/8.1.1/c12_6ranks_standard/dycore/ /fv3core/tests
 ```
 
 (2) To run the tests without opening the docker container (just savepoint tests):
@@ -80,7 +80,7 @@ In the container, physics tests can be run by:
 
 ```shell
 $ DEV=y make dev
-$ pytest -v -s --data_path=/test_data/8.1.0/c12_6ranks_baroclinic_dycore_microphysics/physics/ /fv3gfs-physics/tests --threshold_overrides_file=/fv3gfs-physics/tests/savepoint/translate/overrides/baroclinic.yaml
+$ pytest -v -s --data_path=/test_data/8.1.1/c12_6ranks_baroclinic_dycore_microphysics/physics/ /fv3gfs-physics/tests --threshold_overrides_file=/fv3gfs-physics/tests/savepoint/translate/overrides/baroclinic.yaml
 ```
 In this case, DEV=y mounts the local directory, so any changes in it will take effect without needing to rebuild the container.
 
@@ -94,7 +94,7 @@ $ DEV=y make physics_savepoint_tests
 For parallel tests use:
 
 ```shell
-$ mpirun -np 6 python -m mpi4py -m pytest -v -s -m parallel --data_path=/test_data/8.1.0/c12_6ranks_baroclinic_dycore_microphysics/physics/ /fv3gfs-physics/tests --threshold_overrides_file=/fv3gfs-physics/tests/savepoint/translate/overrides/baroclinic.yaml
+$ mpirun -np 6 python -m mpi4py -m pytest -v -s -m parallel --data_path=/test_data/8.1.1/c12_6ranks_baroclinic_dycore_microphysics/physics/ /fv3gfs-physics/tests --threshold_overrides_file=/fv3gfs-physics/tests/savepoint/translate/overrides/baroclinic.yaml
 ```
 
 or

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ If you are visiting for AMS 2022, we recommend you go to `driver/README.md`.
 
 **WARNING** This repo is under active development and relies on code and data that is not publicly available at this point.
 
-## Getting started
 
 Currently, we support tests in the dynamical core, physics, and util.
 
@@ -14,7 +13,7 @@ This git repository is laid out as a mono-repo, containing multiple independent 
 
 ![Graph of interdependencies of Pace modules, generated from dependences.dot](./dependencies.svg)
 
-### Dynamical core tests
+## Dynamical core tests
 
 Before the top-level build, make sure you have configured the authentication with user credientials and configured Docker with the following commands:
 ```shell
@@ -22,9 +21,9 @@ $ gcloud auth login
 $ gcloud auth configure-docker
 ```
 
-You will also need to update the submodules to include gt4py:
+You will also need to update the git submodules are cloned and at the correct version:
 ```shell
-$ git submodule update --init
+$ git submodule update --init --recursive
 ```
 
 To run dynamical core tests, first get the test data from inside `fv3core` or `fv3gfs-physics` folder, then build `fv3gfs-integration` docker image at the top level.
@@ -65,7 +64,7 @@ $ DEV=y make savepoint_tests_mpi
 
 Additional test options are described under `fv3core` documentation.
 
-### Physics tests
+## Physics tests
 
 Currently, the supported test case is dynamical core + microphysics: e.g., `c12_6ranks_baroclinic_dycore_microphysics` (gs://vcm-fv3gfs-serialized-regression-data/integration-7.2.5/c12_6ranks_baroclinic_dycore_microphysics).
 
@@ -83,7 +82,7 @@ In the container, physics tests can be run by:
 $ DEV=y make dev
 $ pytest -v -s --data_path=/test_data/8.1.0/c12_6ranks_baroclinic_dycore_microphysics/physics/ /fv3gfs-physics/tests --threshold_overrides_file=/fv3gfs-physics/tests/savepoint/translate/overrides/baroclinic.yaml
 ```
-(in this case, DEV=y also mounts the test_data directory, which is needed)
+In this case, DEV=y mounts the local directory, so any changes in it will take effect without needing to rebuild the container.
 
 or use the second method (as in dynamical core testing) outside of the docker container:
 
@@ -106,7 +105,7 @@ $ DEV=y make physics_savepoint_tests_mpi
 
 --------
 
-### Util tests
+## Util tests
 
 Inside the container, util tests can be run from `/pace-util`:
 

--- a/fv3core/Makefile
+++ b/fv3core/Makefile
@@ -3,7 +3,7 @@ include docker/Makefile.image_names
 GCR_URL = us.gcr.io/vcm-ml
 REGRESSION_DATA_STORAGE_BUCKET = gs://vcm-fv3gfs-serialized-regression-data
 EXPERIMENT ?=c12_6ranks_standard
-FORTRAN_SERIALIZED_DATA_VERSION=8.1.0
+FORTRAN_SERIALIZED_DATA_VERSION=8.1.1
 DOCKER_BUILDKIT=1
 SHELL=/bin/bash
 CWD=$(shell pwd)

--- a/fv3gfs-physics/Makefile
+++ b/fv3gfs-physics/Makefile
@@ -14,7 +14,7 @@ MPIRUN_CALL ?=mpirun -np $(NUM_RANKS)
 
 REGRESSION_DATA_STORAGE_BUCKET = gs://vcm-fv3gfs-serialized-regression-data
 EXPERIMENT ?=c12_6ranks_baroclinic_dycore_microphysics
-FORTRAN_SERIALIZED_DATA_VERSION=8.1.0
+FORTRAN_SERIALIZED_DATA_VERSION=8.1.1
 TEST_DATA_TARFILE=dat_files.tar.gz
 TARGET ?= physics
 TEST_DATA_ROOT ?=$(CWD)/../test_data/


### PR DESCRIPTION
## Purpose

Updated the FORTRAN_SERIALIZED_DATA_VERSION to 8.1.1 (version which removed some test points that were expected to fail in 8.1.0).

## Code changes:

- fv3core > Makefile
- fv3gfs-physics > Makefile
- No change to bulk of code, just downloads a different set of test data.

## Infrastructure changes:

- fv3core > Makefile
- fv3gfs-physics > Makefile
- No change to bulk of code, just downloads a different set of test data.

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
