### PR TITLE
Driver: increment time and delete unused function

### DIFF
--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -339,6 +339,9 @@ class Driver:
         """Gather operations unrelated to computation.
         Using a function allows those actions to be removed from the orchestration path.
         """
+        if __debug__:
+            logger.info(f"Finished stepping {step}")
+        self.time += self.config.timestep
         if not ((step + 1) % self.config.diagnostics_config.output_frequency):
             self.diagnostics.store(time=self.time, state=self.state)
         if (
@@ -377,17 +380,6 @@ class Driver:
                 timer=self.performance_config.timestep_timer,
                 dt=self.config.timestep.total_seconds(),
             )
-
-    def step(self, timestep: timedelta):
-        with self.performance_config.timestep_timer.clock("mainloop"):
-            self._step_dynamics(
-                self.state.dycore_state,
-                self.performance_config.timestep_timer,
-            )
-            if not self.config.disable_step_physics:
-                self._step_physics(timestep=timestep.total_seconds())
-        self.time += timestep
-        self.performance_config.collect_performance()
 
     def _step_dynamics(
         self,

--- a/tests/main/driver/test_driver.py
+++ b/tests/main/driver/test_driver.py
@@ -113,6 +113,8 @@ def test_driver(timestep: timedelta, minutes: int):
     assert driver.physics.call_count == config.n_timesteps()
     assert driver.dycore_to_physics.call_count == config.n_timesteps()
     assert driver.end_of_step_update.call_count == config.n_timesteps()
+    final_time = driver._start_time + timestep * config.n_timesteps()
+    assert driver.time == final_time
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose

Driver time stamp is now incremented properly.

#256 

## Code changes:

- driver.py: 
  - increment `self.time`
  - delete `step()` which is not used anymore
  - logger prints out which step it's on if in debug mode
- test_driver: add unit test for driver time

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
