### PR TITLE
Enable fetching basic test data  from public FTP server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Before the top-level build, make sure you have configured the authentication wit
 $ gcloud auth login
 $ gcloud auth configure-docker
 ```
+(Note: if you do not have a GCP account you can still fetch basic unit testing data and can skip this step initially.)
 
 You will also need to update the git submodules are cloned and at the correct version:
 ```shell
@@ -31,6 +32,7 @@ $ make get_test_data
 $ cd ../
 $ make build
 ```
+(Note: if you have not authenticated with a GCP account, you can alternatively fetch test data from an FTP server using `make USE_FTP=yes get_test_data` to get started.)
 
 For serial tests (these take a bit of time), there are two options:
 

--- a/fv3core/Makefile
+++ b/fv3core/Makefile
@@ -17,6 +17,8 @@ TEST_ARGS ?=
 TARGET ?=dycore
 TEST_DATA_ROOT ?=$(CWD)/test_data/
 TEST_DATA_HOST ?=$(TEST_DATA_ROOT)/$(FORTRAN_SERIALIZED_DATA_VERSION)/$(EXPERIMENT)/$(TARGET)
+FTP_SERVER ?=ftp://anonymous:anonymous@ftp.cscs.ch
+TEST_DATA_FTP ?=/in/put/abc/cosmo/fuo/pace/fv3core/$(FORTRAN_SERIALIZED_DATA_VERSION)/$(EXPERIMENT)/$(TARGET)
 FV3UTIL_DIR=$(CWD)/external/pace-util
 
 FV3=fv3core
@@ -102,15 +104,22 @@ endif
 sync_test_data:
 	mkdir -p $(TEST_DATA_HOST) && gsutil -m rsync -r $(DATA_BUCKET) $(TEST_DATA_HOST)
 
+sync_test_data_from_ftp:
+	mkdir -p $(TEST_DATA_HOST) && cd $(TEST_DATA_HOST) && lftp -c "set ftp:list-options -a; open $(FTP_SERVER); mirror --delete --use-cache --verbose --allow-chown --allow-suid --no-umask --parallel=2 --max-errors=0 . $(TEST_DATA_FTP)"
+
 push_python_regressions:
 	gsutil -m cp -r $(TEST_DATA_HOST)/python_regressions $(DATA_BUCKET)python_regressions
 
 get_test_data:
-	if [ ! -f "$(TEST_DATA_HOST)/input.nml" ] || \
-	[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt -)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
-	rm -rf $(TEST_DATA_HOST) && \
-	$(MAKE) sync_test_data && \
-	$(MAKE) unpack_test_data ;\
+	if [ -z "${USE_FTP}" ] ; then \
+		if [ ! -f "$(TEST_DATA_HOST)/input.nml" ] || \
+		[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt -)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
+		rm -rf $(TEST_DATA_HOST) && \
+		$(MAKE) sync_test_data && \
+		$(MAKE) unpack_test_data ;\
+		fi ; \
+	else \
+	  $(MAKE) sync_test_data_from_ftp ; \
 	fi
 
 unpack_test_data:


### PR DESCRIPTION
## Purpose

Fetching test data from GCP has been a pain point for external users. This PR enables fetching of the basic c12 standard test data from a public FTP server.

## Code changes:

- `Makefile` in fv3core has been modified.

## Requirements changes:

- Users using this feature need to have `lftp` installed.

## Infrastructure changes:

- None

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [x] The names of all the new contributors have been added to CONTRIBUTORS.md
