### PR TITLE
Extract gt4py setup from compilation config init

### DIFF
--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -348,8 +348,8 @@ class Driver:
             device_sync=original_config.device_sync,
             run_mode=original_config.run_mode,
             use_minimal_caching=original_config.use_minimal_caching,
-            communicator=communicator,
         )
+        compilation_config.configure_gt4py(communicator)
         self.config.stencil_config.compilation_config = compilation_config
 
     @dace_inhibitor

--- a/dsl/pace/dsl/decomposition.py
+++ b/dsl/pace/dsl/decomposition.py
@@ -121,7 +121,8 @@ def build_cache_path(
         if config.use_minimal_caching:
             if config.compiling_equivalent is None:
                 raise RuntimeError(
-                    "Using a compilation config without setting it up with a communicator"
+                    "Using a compilation config without \
+                    setting it up with a communicator"
                 )
             target_rank_str = f"_{config.compiling_equivalent:06d}"
         else:

--- a/dsl/pace/dsl/decomposition.py
+++ b/dsl/pace/dsl/decomposition.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from gt4py import config as gt_config
 
 from pace.util import TilePartitioner
+from pace.util.communicator import CubedSphereCommunicator
 from pace.util.partitioner import CubedSpherePartitioner
 
 
@@ -103,7 +104,9 @@ def check_cached_path_exists(cache_filepath: str) -> None:
         raise RuntimeError(f"Error: Could not find caches for rank at {cache_filepath}")
 
 
-def build_cache_path(config: CompilationConfig) -> Tuple[str, str]:
+def build_cache_path(
+    config: CompilationConfig, rank: int, size: int
+) -> Tuple[str, str]:
     """generate the GT-Cache path from the config
 
     Args:
@@ -112,30 +115,39 @@ def build_cache_path(config: CompilationConfig) -> Tuple[str, str]:
     Returns:
         Tuple[str, str]: path and individual rank string
     """
-    if config.size == 1:
+    if size == 1:
         target_rank_str = ""
     else:
         if config.use_minimal_caching:
+            if config.compiling_equivalent is None:
+                raise RuntimeError(
+                    "Using a compilation config without setting it up with a communicator"
+                )
             target_rank_str = f"_{config.compiling_equivalent:06d}"
         else:
-            target_rank_str = f"_{config.rank:06d}"
+            target_rank_str = f"_{rank:06d}"
 
     path = f"{gt_config.cache_settings['root_path']}/.gt_cache{target_rank_str}"
     return path, target_rank_str
 
 
-def set_distributed_caches(config: CompilationConfig):
-    """In Run mode, check required file then point current rank cache to source cache"""
+def set_distributed_caches(config: CompilationConfig, rank, size):
+    """Check required file then point current rank cache to source cache"""
+    cache_filepath, target_rank_str = build_cache_path(config, rank, size)
+    check_cached_path_exists(cache_filepath)
 
-    # Check that we have all the file we need to early out in case
-    # of issues.
-    from pace.dsl.stencil_config import RunMode
+    gt_config.cache_settings["root_path"] = os.environ.get("GT_CACHE_DIR_NAME", ".")
+    gt_config.cache_settings["dir_name"] = f".gt_cache{target_rank_str}"
+    print(
+        f"[{config.run_mode}] Rank {config.rank} "
+        f"reading cache {gt_config.cache_settings['dir_name']}"
+    )
 
-    if config.run_mode == RunMode.Run:
-        cache_filepath, target_rank_str = build_cache_path(config)
-        check_cached_path_exists(cache_filepath)
-        gt_config.cache_settings["dir_name"] = f".gt_cache{target_rank_str}"
-        print(
-            f"[{config.run_mode}] Rank {config.rank} "
-            f"reading cache {gt_config.cache_settings['dir_name']}"
+
+def set_building_caches(comm: Optional[CubedSphereCommunicator]) -> None:
+    gt_config.cache_settings["root_path"] = os.environ.get("GT_CACHE_DIR_NAME", ".")
+    if comm:
+        gt_config.cache_settings["dir_name"] = os.environ.get(
+            "GT_CACHE_ROOT", f".gt_cache_{comm.rank:06}"
         )
+    print(f"Rank {comm.rank} " f"using cache {gt_config.cache_settings['dir_name']}")

--- a/dsl/pace/dsl/stencil.py
+++ b/dsl/pace/dsl/stencil.py
@@ -26,10 +26,10 @@ from gtc.passes.oir_pipeline import DefaultPipeline, OirPipeline
 import pace.dsl.gt4py_utils as gt4py_utils
 import pace.util
 from pace.dsl.dace.orchestration import SDFGConvertible
+from pace.dsl.decomposition import block_waiting_for_compilation, unblock_waiting_tiles
 from pace.dsl.stencil_config import CompilationConfig, RunMode, StencilConfig
 from pace.dsl.typing import Index3D, cast_to_index3d
 from pace.util import testing
-from pace.util.decomposition import block_waiting_for_compilation, unblock_waiting_tiles
 from pace.util.halo_data_transformer import QuantityHaloSpec
 from pace.util.mpi import MPI
 

--- a/dsl/pace/dsl/stencil_config.py
+++ b/dsl/pace/dsl/stencil_config.py
@@ -7,14 +7,14 @@ from typing import Any, Callable, Dict, Hashable, Iterable, Optional, Sequence, 
 from gtc.passes.oir_pipeline import DefaultPipeline, OirPipeline
 
 from pace.dsl.dace.dace_config import DaceConfig, DaCeOrchestration
-from pace.dsl.gt4py_utils import is_gpu_backend
-from pace.util.communicator import CubedSphereCommunicator
 from pace.dsl.decomposition import (
     compiling_equivalent,
     determine_rank_is_compiling,
     set_building_caches,
     set_distributed_caches,
 )
+from pace.dsl.gt4py_utils import is_gpu_backend
+from pace.util.communicator import CubedSphereCommunicator
 
 
 class RunMode(enum.Enum):
@@ -102,7 +102,6 @@ class CompilationConfig:
             device_sync=data.get("device_sync", False),
             run_mode=RunMode[data.get("run_mode", "BuildAndRun")],
             use_minimal_caching=data.get("use_minimal_caching", False),
-            communicator=None,
         )
         return instance
 

--- a/fv3core/examples/standalone/runfile/acoustics.py
+++ b/fv3core/examples/standalone/runfile/acoustics.py
@@ -158,6 +158,7 @@ def driver(
             ),
             dace_config=dace_config,
         )
+        stencil_config.compilation_config.configure_gt4py(communicator)
         stencil_factory = pace.dsl.stencil.StencilFactory(
             config=stencil_config,
             grid_indexing=grid.grid_indexing,

--- a/fv3core/examples/standalone/runfile/dynamics.py
+++ b/fv3core/examples/standalone/runfile/dynamics.py
@@ -231,6 +231,7 @@ def setup_dycore(
         ),
         dace_config=dace_config,
     )
+    stencil_config.compilation_config.configure_gt4py(communicator)
     stencil_factory = StencilFactory(
         config=stencil_config,
         grid_indexing=grid.grid_indexing,

--- a/fv3core/tests/mpi/test_doubly_periodic.py
+++ b/fv3core/tests/mpi/test_doubly_periodic.py
@@ -61,12 +61,12 @@ def setup_dycore() -> Tuple[fv3core.DynamicalCore, List[Any]]:
     communicator = pace.util.TileCommunicator(mpi_comm, partitioner)
     stencil_config = pace.dsl.stencil.StencilConfig(
         compilation_config=pace.dsl.stencil.CompilationConfig(
-            communicator=communicator,
             backend=backend,
             rebuild=False,
             validate_args=True,
         )
     )
+    stencil_config.compilation_config.configure_gt4py(communicator)
     sizer = pace.util.SubtileGridSizer.from_tile_params(
         nx_tile=config.npx - 1,
         ny_tile=config.npy - 1,

--- a/stencils/pace/stencils/testing/conftest.py
+++ b/stencils/pace/stencils/testing/conftest.py
@@ -124,6 +124,7 @@ def get_config(backend: str, communicator: Optional[CubedSphereCommunicator]):
             backend=backend,
         ),
     )
+    stencil_config.compilation_config.configure_gt4py(communicator)
     return stencil_config
 
 

--- a/stencils/pace/stencils/testing/test_translate.py
+++ b/stencils/pace/stencils/testing/test_translate.py
@@ -247,6 +247,7 @@ def test_sequential_savepoint(
             backend=backend,
         ),
     )
+    stencil_config.compilation_config.configure_gt4py(None)
     # Reduce error threshold for GPU
     if stencil_config.is_gpu_backend:
         case.testobj.max_error = max(case.testobj.max_error, GPU_MAX_ERR)
@@ -366,6 +367,7 @@ def test_parallel_savepoint(
             backend=backend,
         ),
     )
+    stencil_config.compilation_config.configure_gt4py(communicator)
     # Increase minimum error threshold for GPU
     if stencil_config.is_gpu_backend:
         case.testobj.max_error = max(case.testobj.max_error, GPU_MAX_ERR)

--- a/tests/main/dsl/test_decomposition.py
+++ b/tests/main/dsl/test_decomposition.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 import pytest
 
-from pace.util.decomposition import (
+from pace.dsl.decomposition import (
     block_waiting_for_compilation,
     build_cache_path,
     check_cached_path_exists,


### PR DESCRIPTION
## Purpose

The initialization of a `CompilationConfig` object should not have side-effects. These are removed here.

## Code changes:

- moved `decomposition.py` and it's test from `pace/utils` to `pace/dsl`
- created `configure_gt4py` function for StencilConfig
  - added calls to it where appropriate


## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] Unit tests are added or updated for non-stencil code changes