### PR TITLE
Move decomposition tests to pace-util test directory

### DIFF
--- a/pace-util/tests/mpi/test_decomposition_mpi.py
+++ b/pace-util/tests/mpi/test_decomposition_mpi.py
@@ -1,0 +1,21 @@
+import unittest.mock
+
+import pytest
+from mpi_comm import MPI
+
+from pace.util.decomposition import block_waiting_for_compilation, unblock_waiting_tiles
+
+
+@pytest.mark.parallel
+@pytest.mark.skipif(
+    MPI is None or MPI.COMM_WORLD.Get_size() != 6,
+    reason="mpi4py is not available or pytest was not run in parallel",
+)
+def test_unblock_waiting_tiles():
+    comm = MPI.COMM_WORLD
+    compilation_config = unittest.mock.MagicMock(compiling_equivalent=0)
+    rank = comm.Get_rank()
+    if rank != 0:
+        block_waiting_for_compilation(comm, compilation_config)
+    if rank == 0:
+        unblock_waiting_tiles(comm)


### PR DESCRIPTION
## Purpose

Currently the decomposition tests live inside the pace package, where they do not get run at testing time. This PR moves them to the tests directory, where they will be picked up by CI.

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes

