### PR TITLE
Ensure kslice_from_inputs makes a slice of ints

### DIFF
--- a/stencils/pace/stencils/corners.py
+++ b/stencils/pace/stencils/corners.py
@@ -117,9 +117,9 @@ class CopyCornersXY:
 
 
 def kslice_from_inputs(
-    kstart, nk: Optional[int], grid_indexer: GridIndexing
+    kstart: int, nk: Optional[int], grid_indexer: GridIndexing
 ) -> Tuple[slice, int]:
-    # This expects an integer, but it casts in case something was implicitly converted
+    # This expects ints, but it casts in case something was implicitly converted
     # to a float before this call.
     if nk is None:
         nk = grid_indexer.domain[2] - kstart

--- a/stencils/pace/stencils/corners.py
+++ b/stencils/pace/stencils/corners.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence, Tuple
 
 from gt4py import gtscript
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
@@ -116,11 +116,15 @@ class CopyCornersXY:
         return field, self._y_field
 
 
-def kslice_from_inputs(kstart, nk, grid_indexer: GridIndexing):
+def kslice_from_inputs(
+    kstart, nk: Optional[int], grid_indexer: GridIndexing
+) -> Tuple[slice, int]:
+    # This expects an integer, but it casts in case something was implicitly converted
+    # to a float before this call.
     if nk is None:
         nk = grid_indexer.domain[2] - kstart
     kslice = slice(int(kstart), int(kstart + nk))
-    return [kslice, int(nk)]
+    return (kslice, int(nk))
 
 
 @gtscript.function

--- a/stencils/pace/stencils/corners.py
+++ b/stencils/pace/stencils/corners.py
@@ -119,8 +119,8 @@ class CopyCornersXY:
 def kslice_from_inputs(kstart, nk, grid_indexer: GridIndexing):
     if nk is None:
         nk = grid_indexer.domain[2] - kstart
-    kslice = slice(kstart, kstart + nk)
-    return [kslice, nk]
+    kslice = slice(int(kstart), int(kstart + nk))
+    return [kslice, int(nk)]
 
 
 @gtscript.function


### PR DESCRIPTION
## Purpose

The `MetricTerms` class agrid init fails on 54 ranks.

## Code changes:

- Cast nk to an integer so slices don't have floats in `kslice_from_inputs`.
