### PR TITLE
Run init tests on savepoint_tests_mpi

### DIFF
--- a/fv3core/.jenkins/actions/run_parallel_regression_tests.sh
+++ b/fv3core/.jenkins/actions/run_parallel_regression_tests.sh
@@ -9,12 +9,16 @@ make get_test_data
 
 if [ ${python_env} == "virtualenv" ]; then
     CONTAINER_CMD="" MPIRUN_ARGS="" make savepoint_tests_mpi
+    TARGET=init CONTAINER_CMD="" MPIRUN_ARGS="" make savepoint_tests_mpi
 else
     make savepoint_tests_mpi
+    TARGET=init make savepoint_tests_mpi
 fi
 export TEST_ARGS="${TEST_ARGS} --compute_grid"
 if [ ${python_env} == "virtualenv" ]; then
     CONTAINER_CMD="" MPIRUN_ARGS="" make savepoint_tests_mpi
+    TARGET=init CONTAINER_CMD="" MPIRUN_ARGS="" make savepoint_tests_mpi
 else
     make savepoint_tests_mpi
+    TARGET=init make savepoint_tests_mpi
 fi

--- a/fv3core/tests/savepoint/translate/translate_grid.py
+++ b/fv3core/tests/savepoint/translate/translate_grid.py
@@ -2326,7 +2326,7 @@ class TranslateInitGridUtils(ParallelTranslateGrid):
         grid_generator = MetricTerms.from_tile_sizing(
             npx=namelist.npx,
             npy=namelist.npy,
-            npz=inputs["npz"],
+            npz=int(inputs["npz"]),
             communicator=communicator,
             backend=self.stencil_factory.backend,
         )

--- a/pace-util/pace/util/testing/comparison.py
+++ b/pace-util/pace/util/testing/comparison.py
@@ -10,7 +10,7 @@ def compare_arr(computed_data, ref_data):
     """
     if ref_data.dtype in (np.float64, np.int64, np.float32, np.int32):
         denom = np.abs(ref_data) + np.abs(computed_data)
-        compare = 2.0 * np.abs(computed_data - ref_data) / denom
+        compare = np.asarray(2.0 * np.abs(computed_data - ref_data) / denom)
         compare[denom == 0] = 0.0
         return compare
     elif ref_data.dtype in (np.bool,):
@@ -58,5 +58,11 @@ def success_array(
 
 def success(computed_data, ref_data, eps, ignore_near_zero_errors, near_zero=0.0):
     return np.all(
-        success_array(computed_data, ref_data, eps, ignore_near_zero_errors, near_zero)
+        success_array(
+            np.asarray(computed_data),
+            np.asarray(ref_data),
+            eps,
+            ignore_near_zero_errors,
+            near_zero,
+        )
     )


### PR DESCRIPTION
## Purpose

@oelbert and I noticed that the Grid tests are not run in CI 😳 😨 😱 😠 , since the CI only uses the default `TARGET` and the grid init was put into `TARGET=init` instead of `TARGET=dycore`.

## Code changes:

- Add tests.
- Cast `nk` to an `int` to fix one grid-related test.
