### PR TITLE
Fix fetching test data from FTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Then build the `pace` docker image at the top level.
 ```shell
 make build
 ```
-(Note: if you have not authenticated with a GCP account, you can alternatively fetch test data from an FTP server using `make USE_FTP=yes get_test_data` to get started.)
 
 ## Downloading test data
 
@@ -45,7 +44,7 @@ make get_test_data
 cd ..
 ```
 
-If you do not have a GCP account, there is an option to download basic test data from a public FTP server and you can skip the GCP authentication step above. To download test data from the FTP server, use `make USE_FTP=yes get_test_data` instead and this will avoid fetching from a GCP storage bucket.
+If you do not have a GCP account, there is an option to download basic test data from a public FTP server and you can skip the GCP authentication step above. To download test data from the FTP server, use `make USE_FTP=yes get_test_data` instead and this will avoid fetching from a GCP storage bucket. You will need a valid in stallation of the `lftp` command.
 
 ## Running the tests (manually)
 

--- a/fv3core/Makefile
+++ b/fv3core/Makefile
@@ -18,7 +18,7 @@ TARGET ?=dycore
 TEST_DATA_ROOT ?=$(CWD)/test_data/
 TEST_DATA_HOST ?=$(TEST_DATA_ROOT)/$(FORTRAN_SERIALIZED_DATA_VERSION)/$(EXPERIMENT)/$(TARGET)
 FTP_SERVER ?=ftp://anonymous:anonymous@ftp.cscs.ch
-TEST_DATA_FTP ?=/in/put/abc/cosmo/fuo/pace/fv3core/$(FORTRAN_SERIALIZED_DATA_VERSION)/$(EXPERIMENT)/$(TARGET)
+TEST_DATA_FTP ?=in/put/abc/cosmo/fuo/pace/fv3core/
 FV3UTIL_DIR=$(CWD)/external/pace-util
 
 FV3=fv3core
@@ -105,7 +105,7 @@ sync_test_data:
 	mkdir -p $(TEST_DATA_HOST) && gsutil -m rsync -r $(DATA_BUCKET) $(TEST_DATA_HOST)
 
 sync_test_data_from_ftp:
-	mkdir -p $(TEST_DATA_HOST) && cd $(TEST_DATA_HOST) && lftp -c "set ftp:list-options -a; open $(FTP_SERVER); mirror --delete --use-cache --verbose --allow-chown --allow-suid --no-umask --parallel=2 --max-errors=0 . $(TEST_DATA_FTP)"
+	mkdir -p $(TEST_DATA_HOST) && cd $(TEST_DATA_ROOT) && lftp -c "set ftp:list-options -a; open $(FTP_SERVER); cd $(TEST_DATA_FTP); mirror --delete --use-cache --verbose --allow-chown --allow-suid --no-umask --parallel=2 --max-errors=0 . ."
 
 push_python_regressions:
 	gsutil -m cp -r $(TEST_DATA_HOST)/python_regressions $(DATA_BUCKET)python_regressions
@@ -113,19 +113,21 @@ push_python_regressions:
 get_test_data:
 	if [ -z "${USE_FTP}" ] ; then \
 		if [ ! -f "$(TEST_DATA_HOST)/input.nml" ] || \
-		[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt -)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
-		rm -rf $(TEST_DATA_HOST) && \
-		$(MAKE) sync_test_data && \
-		$(MAKE) unpack_test_data ;\
+		[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt -)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)" ] ; then \
+			rm -rf $(TEST_DATA_HOST) ; \
+			$(MAKE) sync_test_data ; \
+			$(MAKE) unpack_test_data ; \
 		fi ; \
 	else \
-	  $(MAKE) sync_test_data_from_ftp ; \
+		$(MAKE) sync_test_data_from_ftp ; \
+		$(MAKE) unpack_test_data ; \
 	fi
 
 unpack_test_data:
 	if [ -f $(TEST_DATA_TARPATH) ]; then \
-	cd $(TEST_DATA_HOST) && tar -xf $(TEST_DATA_TARFILE) && \
-	rm $(TEST_DATA_TARFILE); fi
+		cd $(TEST_DATA_HOST) && tar -xf $(TEST_DATA_TARFILE) && \
+		rm $(TEST_DATA_TARFILE); \
+	fi
 
 list_test_data_options:
 	gsutil ls $(REGRESSION_DATA_STORAGE_BUCKET)/$(FORTRAN_SERIALIZED_DATA_VERSION)

--- a/fv3core/README.md
+++ b/fv3core/README.md
@@ -40,7 +40,9 @@ If you want to download test data run
 $ make get_test_data
 ```
 
-And the c12_6ranks_standard data will download into the `test_data` directory
+And the c12_6ranks_standard data will download into the `test_data` directory.
+
+If you do not have a GCP account, there is an option to download basic test data from a public FTP server and you can skip the GCP authentication step above. To download test data from the FTP server, use `make USE_FTP=yes get_test_data` instead and this will avoid fetching from a GCP storage bucket. You will need a valid in stallation of the `lftp` command.
 
 MPI parallel tests (that run that way to exercise halo updates in the model) can also be run with:
 
@@ -96,7 +98,7 @@ These will mount your current code into the fv3core container and run it rather 
 
 ## Running tests inside a container
 
-If you to prefer to work interactively inside the fv3core container, get the test data and build the docker image:
+If you to prefer to work interactively inside the fv3core container, get the test data and build the docker image (see above if you do not have a GCP account and want to get test data):
 ```shell
 $ make get_test_data
 ```

--- a/fv3gfs-physics/Makefile
+++ b/fv3gfs-physics/Makefile
@@ -21,6 +21,8 @@ TARGET ?= physics
 TEST_DATA_ROOT ?=$(CWD)/../test_data/
 TEST_DATA_HOST ?=$(TEST_DATA_ROOT)/$(FORTRAN_SERIALIZED_DATA_VERSION)/$(EXPERIMENT)/$(TARGET)/
 TEST_DATA_TARPATH=$(TEST_DATA_HOST)/$(TEST_DATA_TARFILE)
+FTP_SERVER ?=ftp://anonymous:anonymous@ftp.cscs.ch
+TEST_DATA_FTP ?=in/put/abc/cosmo/fuo/pace/fv3gfs-physics
 FV3UTIL_DIR=$(CWD)/../pace-util
 DATA_BUCKET ?= $(REGRESSION_DATA_STORAGE_BUCKET)/$(FORTRAN_SERIALIZED_DATA_VERSION)/$(EXPERIMENT)/$(TARGET)/
 
@@ -48,17 +50,26 @@ build:
 sync_test_data:
 	mkdir -p $(TEST_DATA_HOST) && gsutil -m rsync -r $(DATA_BUCKET) $(TEST_DATA_HOST)
 
+sync_test_data_from_ftp:
+	mkdir -p $(TEST_DATA_HOST) && cd $(TEST_DATA_ROOT) && lftp -c "set ftp:list-options -a; open $(FTP_SERVER); cd $(TEST_DATA_FTP); mirror --delete --use-cache --verbose --allow-chown --allow-suid --no-umask --parallel=2 --max-errors=0 . ."
+
 unpack_test_data:
 	if [ -f $(TEST_DATA_TARPATH) ]; then \
-	cd $(TEST_DATA_HOST) && tar -xf $(TEST_DATA_TARFILE) && \
-	rm $(TEST_DATA_TARFILE); fi
+		cd $(TEST_DATA_HOST) && tar -xf $(TEST_DATA_TARFILE) && \
+		rm $(TEST_DATA_TARFILE); \
+	fi
 
 get_test_data:
-	if [ ! -f "$(TEST_DATA_HOST)/input.nml" ] || \
-	[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt -)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)"  ]; then \
-	rm -rf $(TEST_DATA_HOST) && \
-	$(MAKE) sync_test_data && \
-	$(MAKE) unpack_test_data ;\
+	if [ -z "${USE_FTP}" ] ; then \
+		if [ ! -f "$(TEST_DATA_HOST)/input.nml" ] || \
+		[ "$$(gsutil cp $(DATA_BUCKET)md5sums.txt -)" != "$$(cat $(TEST_DATA_HOST)/md5sums.txt)" ] ; then \
+			rm -rf $(TEST_DATA_HOST) ; \
+			$(MAKE) sync_test_data ; \
+			$(MAKE) unpack_test_data ; \
+		fi ; \
+	else \
+		$(MAKE) sync_test_data_from_ftp ; \
+		$(MAKE) unpack_test_data ; \
 	fi
 
 test_base:


### PR DESCRIPTION
## Purpose

Now that finally we can create new directories on the FTP server, it was feasible to test this feature. There were still some issues and also the physical parameterizations did not support fetching data from FTP server.

Remove the sections below which do not apply.

## Code changes:

- `Makefile` both in `fv3core/` and `fv3gfs-physics/` have been adapted.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
