### PR TITLE
Fix the model inconsistencies between 6 and 54 rank runs

### DIFF
--- a/dsl/pace/dsl/gt4py_utils.py
+++ b/dsl/pace/dsl/gt4py_utils.py
@@ -355,9 +355,13 @@ def asarray(array, to_type=np.ndarray, dtype=None, order=None):
             return np.asarray(array, dtype, order)
         else:
             return cp.asarray(array, dtype, order)
-    if cp and hasattr(array, "data") and (
-        isinstance(array, memoryview)
-        or isinstance(array.data, (cp.ndarray, cp.cuda.memory.MemoryPointer))
+    if (
+        cp
+        and hasattr(array, "data")
+        and (
+            isinstance(array, memoryview)
+            or isinstance(array.data, (cp.ndarray, cp.cuda.memory.MemoryPointer))
+        )
     ):
         if to_type is np.ndarray:
             order = "F" if order is None else order

--- a/dsl/pace/dsl/gt4py_utils.py
+++ b/dsl/pace/dsl/gt4py_utils.py
@@ -355,7 +355,7 @@ def asarray(array, to_type=np.ndarray, dtype=None, order=None):
             return np.asarray(array, dtype, order)
         else:
             return cp.asarray(array, dtype, order)
-    if cp and (
+    if cp and hasattr(array, "data") and (
         isinstance(array, memoryview)
         or isinstance(array.data, (cp.ndarray, cp.cuda.memory.MemoryPointer))
     ):

--- a/dsl/pace/dsl/gt4py_utils.py
+++ b/dsl/pace/dsl/gt4py_utils.py
@@ -355,12 +355,11 @@ def asarray(array, to_type=np.ndarray, dtype=None, order=None):
             return np.asarray(array, dtype, order)
         else:
             return cp.asarray(array, dtype, order)
-    if (
-        cp
-        and hasattr(array, "data")
-        and (
-            isinstance(array, memoryview)
-            or isinstance(array.data, (cp.ndarray, cp.cuda.memory.MemoryPointer))
+    if cp and (
+        isinstance(array, memoryview)
+        or (
+            hasattr(array, "data")
+            and isinstance(array.data, (cp.ndarray, cp.cuda.memory.MemoryPointer))
         )
     ):
         if to_type is np.ndarray:

--- a/pace-util/HISTORY.md
+++ b/pace-util/HISTORY.md
@@ -9,9 +9,11 @@ Major changes:
 - Added Checkpointer and NullCheckpointer classes
 - Added SnapshotCheckpointer
 - Comm and Request abstract base classes are added to the top level
+- Added the following attributes/methods to the Comm abstract base classes: `allreduce`
 
 Minor changes:
 - Deleted deprecated `finish_halo_update` method from CubedSphereCommunicator
+- fixed a bug in `pace.util.grid.` where `_reduce_global_area_minmaxes` would use local values instead of the gathered ones
 
 Minor changes:
 - Fixed a bug in normalize_vector(xyz) in `pace.util.grid.gnomonic` where it would divide the input by cells-per-tile, where it should not.

--- a/pace-util/HISTORY.md
+++ b/pace-util/HISTORY.md
@@ -13,7 +13,7 @@ Major changes:
 
 Minor changes:
 - Deleted deprecated `finish_halo_update` method from CubedSphereCommunicator
-- fixed a bug in `pace.util.grid.` where `_reduce_global_area_minmaxes` would use local values instead of the gathered ones
+- fixed a bug in `pace.util.grid` where `_reduce_global_area_minmaxes` would use local values instead of the gathered ones
 
 Minor changes:
 - Fixed a bug in normalize_vector(xyz) in `pace.util.grid.gnomonic` where it would divide the input by cells-per-tile, where it should not.

--- a/pace-util/pace/util/caching_comm.py
+++ b/pace-util/pace/util/caching_comm.py
@@ -137,6 +137,9 @@ class CachingCommReader(Comm):
         new_data = self._data.get_split()
         return CachingCommReader(data=new_data)
 
+    def allreduce(self, sendobj, op=None) -> Any:
+        raise NotImplementedError()
+
     @classmethod
     def load(cls, file: BinaryIO) -> "CachingCommReader":
         data = CachingCommData.load(file)
@@ -212,3 +215,6 @@ class CachingCommWriter(Comm):
 
     def dump(self, file: BinaryIO):
         self._data.dump(file)
+
+    def allreduce(self, sendobj, op=None) -> Any:
+        raise NotImplementedError()

--- a/pace-util/pace/util/caching_comm.py
+++ b/pace-util/pace/util/caching_comm.py
@@ -49,12 +49,14 @@ class CachingCommData:
     size: int
     bcast_objects: List[Any] = dataclasses.field(default_factory=list)
     received_buffers: List[np.ndarray] = dataclasses.field(default_factory=list)
+    generic_obj_buffers: List[Any] = dataclasses.field(default_factory=list)
     split_data: List["CachingCommData"] = dataclasses.field(default_factory=list)
 
     def __post_init__(self):
         self._i_bcast = 0
         self._i_buffers = 0
         self._i_split = 0
+        self._i_generic_obj = 0
 
     def get_bcast(self):
         return_value = self.bcast_objects[self._i_bcast]
@@ -64,6 +66,11 @@ class CachingCommData:
     def get_buffer(self):
         return_value = self.received_buffers[self._i_buffers]
         self._i_buffers += 1
+        return return_value
+
+    def get_generic_obj(self):
+        return_value = self.generic_obj_buffers[self._i_generic_obj]
+        self._i_generic_obj += 1
         return return_value
 
     def get_split(self):
@@ -138,7 +145,7 @@ class CachingCommReader(Comm):
         return CachingCommReader(data=new_data)
 
     def allreduce(self, sendobj, op=None) -> Any:
-        raise NotImplementedError()
+        return self._data.get_generic_obj()
 
     @classmethod
     def load(cls, file: BinaryIO) -> "CachingCommReader":
@@ -217,4 +224,6 @@ class CachingCommWriter(Comm):
         self._data.dump(file)
 
     def allreduce(self, sendobj, op=None) -> Any:
-        raise NotImplementedError()
+        result = self._comm.allreduce(sendobj, op)
+        self._data.generic_obj_buffers.append(copy.deepcopy(result))
+        return result

--- a/pace-util/pace/util/comm.py
+++ b/pace-util/pace/util/comm.py
@@ -63,7 +63,7 @@ class Comm(abc.ABC):
     @abc.abstractmethod
     def Split(self, color, key) -> "Comm":
         ...
-    
-    @abc.abstractmethod 
+
+    @abc.abstractmethod
     def allreduce(self, sendobj, op=None) -> Any:
         ...

--- a/pace-util/pace/util/comm.py
+++ b/pace-util/pace/util/comm.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Optional, TypeVar
+from typing import Any, Optional, TypeVar
 
 
 T = TypeVar("T")

--- a/pace-util/pace/util/comm.py
+++ b/pace-util/pace/util/comm.py
@@ -63,3 +63,7 @@ class Comm(abc.ABC):
     @abc.abstractmethod
     def Split(self, color, key) -> "Comm":
         ...
+    
+    @abc.abstractmethod 
+    def allreduce(self, sendobj, op=None) -> Any:
+        ...

--- a/pace-util/pace/util/grid/generation.py
+++ b/pace-util/pace/util/grid/generation.py
@@ -2232,7 +2232,7 @@ class MetricTerms:
         max_area = self._np.max(self.area.storage[3:-4, 3:-4])[()]
         min_area_c = self._np.min(self.area_c.storage[3:-4, 3:-4])[()]
         max_area_c = self._np.max(self.area_c.storage[3:-4, 3:-4])[()]
-        self._da_min = self._comm.comm.allreduce(min_area, min).item()
-        self._da_max = self._comm.comm.allreduce(max_area, max).item()
-        self._da_min_c = self._comm.comm.allreduce(min_area_c, min).item()
-        self._da_max_c = self._comm.comm.allreduce(max_area_c, max).item()
+        self._da_min = float(self._comm.comm.allreduce(min_area, min))
+        self._da_max = float(self._comm.comm.allreduce(max_area, max))
+        self._da_min_c = float(self._comm.comm.allreduce(min_area_c, min))
+        self._da_max_c = float(self._comm.comm.allreduce(max_area_c, max))

--- a/pace-util/pace/util/grid/generation.py
+++ b/pace-util/pace/util/grid/generation.py
@@ -2232,13 +2232,7 @@ class MetricTerms:
         max_area = self._np.max(self.area.storage[3:-4, 3:-4])[()]
         min_area_c = self._np.min(self.area_c.storage[3:-4, 3:-4])[()]
         max_area_c = self._np.max(self.area_c.storage[3:-4, 3:-4])[()]
-        try:
-            self._da_min = self._comm.comm.allreduce(min_area, min)
-            self._da_max = self._comm.comm.allreduce(max_area, max)
-            self._da_min_c = self._comm.comm.allreduce(min_area_c, min)
-            self._da_max_c = self._comm.comm.allreduce(max_area_c, max)
-        except AttributeError:
-            self._da_min = min_area
-            self._da_max = max_area
-            self._da_min_c = min_area_c
-            self._da_max_c = max_area_c
+        self._da_min = self._comm.comm.allreduce(min_area, min).item()
+        self._da_max = self._comm.comm.allreduce(max_area, max).item()
+        self._da_min_c = self._comm.comm.allreduce(min_area_c, min).item()
+        self._da_max_c = self._comm.comm.allreduce(max_area_c, max).item()

--- a/pace-util/pace/util/local_comm.py
+++ b/pace-util/pace/util/local_comm.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from typing import Any
 
 from .comm import Comm
 from .utils import ensure_contiguous, safe_assign_array
@@ -177,3 +178,9 @@ class LocalComm(Comm):
             comm.total_ranks = total_ranks
         self._split_comms[color].append(new_comm)
         return new_comm
+
+    def allreduce(self, sendobj, op=None) -> Any:
+        raise NotImplementedError(
+            "sendrecv fundamentally cannot be written for LocalComm, "
+            "as it requires synchronicity"
+        )

--- a/pace-util/pace/util/mpi.py
+++ b/pace-util/pace/util/mpi.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     MPI = None
 import logging
-from typing import Any, Callable, Optional, TypeVar, Union, cast
+from typing import Any, Optional, TypeVar, cast
 
 from .comm import Comm, Request
 

--- a/pace-util/pace/util/mpi.py
+++ b/pace-util/pace/util/mpi.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     MPI = None
 import logging
-from typing import Optional, TypeVar, cast
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 from .comm import Comm, Request
 
@@ -69,3 +69,7 @@ class MPIComm(Comm):
             "Split on rank %s with color %s, key %s", self._comm.Get_rank(), color, key
         )
         return self._comm.Split(color, key)
+
+    def allreduce(self, sendobj, op=None) -> Any:
+        logger.debug("allreduce on rank %s with operator %s", self._comm.Get_rank(), op)
+        return self._comm.allreduce(sendobj, op)

--- a/pace-util/pace/util/null_comm.py
+++ b/pace-util/pace/util/null_comm.py
@@ -86,3 +86,6 @@ class NullComm(Comm):
             comm.total_ranks = total_ranks
         self._split_comms[color].append(new_comm)
         return new_comm
+
+    def allreduce(self, sendobj, op=None) -> Any:
+        return self._fill_value


### PR DESCRIPTION
## Purpose

We have seen inconsistencies between 6 and 54 rank runs. These should not eixist and get solved by this.

## Code changes:

- Add the `allreduce` method to Comm, MPIComm and NullComm
- Assert LocalComm in `allreduce` because it requires synchronicity. 
- Removed the try-except block in `generation.py` in the `_reduce_global_area_minmaxes` function.
- updated `gt4py_utils.py` to properly handle scalars

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] For each public change and fix in `pace-util`, HISTORY has been updated