### PR TITLE
clean up checking

### DIFF
--- a/dsl/pace/dsl/stencil_config.py
+++ b/dsl/pace/dsl/stencil_config.py
@@ -4,7 +4,6 @@ import hashlib
 import re
 from typing import Any, Callable, Dict, Hashable, Iterable, Optional, Sequence, Tuple
 
-import numpy as np
 from gtc.passes.oir_pipeline import DefaultPipeline, OirPipeline
 
 from pace.dsl.dace.dace_config import DaceConfig, DaCeOrchestration

--- a/dsl/pace/dsl/stencil_config.py
+++ b/dsl/pace/dsl/stencil_config.py
@@ -68,13 +68,6 @@ class CompilationConfig:
             raise RuntimeError(
                 "Trying to run with a non-square layout is not supported"
             )
-        if (
-            communicator.partitioner.layout[0] > 3
-            or communicator.partitioner.layout[1] > 3
-        ) and (self.run_mode != RunMode.Run and self.use_minimal_caching):
-            raise RuntimeError(
-                "Can't compile with a layout larger than 3x3 with minimal caching on"
-            )
 
     def get_decomposition_info_from_comm(
         self, communicator: Optional[CubedSphereCommunicator]

--- a/dsl/pace/dsl/stencil_config.py
+++ b/dsl/pace/dsl/stencil_config.py
@@ -63,7 +63,15 @@ class CompilationConfig:
         if communicator:
             set_distributed_caches(self)
 
-    def check_communicator(self, communicator: CubedSphereCommunicator):
+    def check_communicator(self, communicator: CubedSphereCommunicator) -> None:
+        """Checks that the communicator has a square layout
+
+        Args:
+            communicator (CubedSphereCommunicator): communicator to use
+
+        Raises:
+            RuntimeError: If non-square layout is given
+        """
         if communicator.partitioner.layout[0] != communicator.partitioner.layout[1]:
             raise RuntimeError(
                 "Trying to run with a non-square layout is not supported"

--- a/pace-util/pace/util/decomposition.py
+++ b/pace-util/pace/util/decomposition.py
@@ -29,7 +29,7 @@ def compiling_equivalent(rank: int, partitioner: TilePartitioner):
                 return 2  # "01"
             if partitioner.tile.on_tile_right(rank):
                 return 3  # "11"
-    if partitioner.layout == (3, 3):
+    else:
         if partitioner.tile.on_tile_bottom(rank):
             if partitioner.tile.on_tile_left(rank):
                 return 0  # "00"
@@ -51,10 +51,6 @@ def compiling_equivalent(rank: int, partitioner: TilePartitioner):
                 return 5  # "21"
             else:
                 return 4  # "11"
-    else:
-        raise RuntimeError(
-            "Can't compile with a layout larger than 3x3 with minimal caching on"
-        )
 
 
 def determine_rank_is_compiling(rank: int, partitioner: CubedSpherePartitioner) -> bool:


### PR DESCRIPTION
## Purpose

There was a bug in `decomposition.py` to raise a faulty assertion when just running on a higher node-count. This fixes that problem.


## Code changes:

- Added the correct check for faulty layouts in `stencil_config.py` 
- Removed the faulty check in `decomposition.py`
- added test for this in `test_compilation_config.py`

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] Unit tests are added or updated for non-stencil code changes
