### PR TITLE
do not build physics if disabled

### DIFF
--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -20,6 +20,7 @@ from fv3core.initialization.dycore_state import DycoreState
 from pace.dsl.dace.dace_config import DaceConfig
 from pace.dsl.dace.orchestration import dace_inhibitor, orchestrate
 from pace.dsl.stencil_config import CompilationConfig, RunMode
+
 # TODO: move update_atmos_state into pace.driver
 from pace.stencils import update_atmos_state
 from pace.util.communicator import CubedSphereCommunicator

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -284,7 +284,6 @@ class Driver:
                 n_split=self.config.dycore_config.n_split,
                 state=self.state.dycore_state,
             )
-
             if not config.dycore_only and not config.disable_step_physics:
                 self.physics = fv3gfs.physics.Physics(
                     stencil_factory=self.stencil_factory,
@@ -311,6 +310,10 @@ class Driver:
                     apply_tendencies=self.config.apply_tendencies,
                     tendency_state=self.state.tendency_state,
                 )
+            self.diagnostics = config.diagnostics_config.diagnostics_factory(
+                partitioner=communicator.partitioner,
+                comm=self.comm,
+            )
             self.restart = pace.driver.Restart(
                 save_restart=self.config.save_restart,
                 intermediate_restart=self.config.intermediate_restart,

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -295,7 +295,7 @@ class Driver:
                 self.dycore_to_physics = update_atmos_state.DycoreToPhysics(
                     stencil_factory=self.stencil_factory,
                     dycore_config=self.config.dycore_config,
-                    do_dry_convective_adjustment=self.config.do_dry_convective_adjustment,
+                    do_dry_convective_adjust=self.config.do_dry_convective_adjustment,
                     dycore_only=self.config.dycore_only,
                 )
                 self.end_of_step_update = update_atmos_state.UpdateAtmosphereState(

--- a/stencils/pace/stencils/update_atmos_state.py
+++ b/stencils/pace/stencils/update_atmos_state.py
@@ -150,7 +150,7 @@ class DycoreToPhysics:
         self,
         stencil_factory: StencilFactory,
         dycore_config: fv3core.DynamicalCoreConfig,
-        do_dry_convective_adjustment: bool,
+        do_dry_convective_adjust: bool,
         dycore_only: bool,
     ):
         orchestrate(
@@ -168,7 +168,7 @@ class DycoreToPhysics:
             ],
             compute_halos=(0, 0),
         )
-        self._do_dry_convective_adjustment = do_dry_convective_adjustment
+        self._do_dry_convective_adjustment = do_dry_convective_adjust
         self._dycore_only = dycore_only
         if self._do_dry_convective_adjustment:
             self._fv_subgridz = fv_subgridz.DryConvectiveAdjustment(


### PR DESCRIPTION
## Purpose

We are currently still building the entire physics package even if we're not running it. This solves that problem

## Code changes:

- Change `driver.py` to not build physics components if they are not used

