### PR TITLE
Clean up test decomposition

### DIFF
--- a/pace-util/tests/test_decomposition.py
+++ b/pace-util/tests/test_decomposition.py
@@ -35,13 +35,6 @@ def test_determine_rank_is_compiling(
 
 
 @pytest.mark.sequential
-def test_determine_rank_is_compiling_large():
-    with pytest.raises(RuntimeError):
-        partitioner = CubedSpherePartitioner(TilePartitioner((4, 4)))
-        determine_rank_is_compiling(0, partitioner)
-
-
-@pytest.mark.sequential
 def test_check_cached_path_exists():
     with pytest.raises(RuntimeError):
         check_cached_path_exists("notarealpath")


### PR DESCRIPTION
## Purpose

Test file was put in the wrong folder and not getting tested. 

## Code changes:

- test_decomposition: delete `test_determine_rank_is_compiling_large` as compiling at scale is allowed

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes
