### PR TITLE
Make DycoreState a statically-defined type

### DIFF
--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -295,6 +295,7 @@ class Driver:
                 stencil_factory=self.stencil_factory,
                 damping_coefficients=self.state.damping_coefficients,
                 config=self.config.dycore_config,
+                timestep=self.config.timestep,
                 phis=self.state.dycore_state.phis,
                 state=self.state.dycore_state,
             )

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -299,13 +299,6 @@ class Driver:
                 state=self.state.dycore_state,
             )
 
-            self.dycore.update_state(
-                conserve_total_energy=self.config.dycore_config.consv_te,
-                do_adiabatic_init=False,
-                timestep=self.config.timestep.total_seconds(),
-                n_split=self.config.dycore_config.n_split,
-                state=self.state.dycore_state,
-            )
             if not config.dycore_only and not config.disable_step_physics:
                 self.physics = pace.physics.Physics(
                     stencil_factory=self.stencil_factory,

--- a/fv3core/examples/standalone/runfile/dynamics.py
+++ b/fv3core/examples/standalone/runfile/dynamics.py
@@ -264,13 +264,6 @@ def setup_dycore(
         phis=state.phis,
         state=state,
     )
-    dycore.update_state(
-        conserve_total_energy=dycore_config.consv_te,
-        do_adiabatic_init=False,
-        timestep=dycore_config.dt_atmos,
-        n_split=dycore_config.n_split,
-        state=state,
-    )
     return dycore, state, stencil_factory
 
 

--- a/fv3core/pace/fv3core/initialization/dycore_state.py
+++ b/fv3core/pace/fv3core/initialization/dycore_state.py
@@ -276,7 +276,6 @@ class DycoreState:
             "intent": "in",
         }
     )
-    do_adiabatic_init: bool = field(default=False)
     bdt: float = field(default=0.0)
     mdt: float = field(default=0.0)
 
@@ -336,7 +335,6 @@ class DycoreState:
         cls,
         storages: Mapping[str, Any],
         sizer: pace.util.GridSizer,
-        do_adiabatic_init: bool = False,
         bdt: float = 0.0,
         mdt: float = 0.0,
     ):
@@ -352,7 +350,7 @@ class DycoreState:
                     extent=sizer.get_extent(dims),
                 )
                 inputs[_field.name] = quantity
-        return cls(**inputs, do_adiabatic_init=do_adiabatic_init, bdt=bdt, mdt=mdt)
+        return cls(**inputs, bdt=bdt, mdt=mdt)
 
     @property
     def xr_dataset(self):

--- a/fv3core/pace/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/pace/fv3core/stencils/fv_dynamics.py
@@ -1,4 +1,6 @@
-from typing import Dict, Optional
+import logging
+from datetime import timedelta
+from typing import Dict, Mapping, Optional
 
 from dace.frontend.python.interface import nounroll as dace_no_unroll
 from gt4py.gtscript import PARALLEL, computation, interval, log
@@ -25,6 +27,8 @@ from pace.util.grid import DampingCoefficients, GridData
 from pace.util.mpi import MPI
 from pace.util.quantity import Quantity
 
+
+logger = logging.getLogger(__name__)
 
 # nq is actually given by ncnst - pnats, where those are given in atmosphere.F90 by:
 # ncnst = Atm(mytile)%ncnst
@@ -69,14 +73,16 @@ def init_pfull(
         pfull = (ph2 - ph1) / log(ph2 / ph1)
 
 
-def fvdyn_temporaries(quantity_factory: pace.util.QuantityFactory):
+def fvdyn_temporaries(
+    quantity_factory: pace.util.QuantityFactory,
+) -> Mapping[str, Quantity]:
     tmps = {}
     for name in ["te_2d", "te0_2d", "wsd"]:
         quantity = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM], units="unknown"
         )
         tmps[name] = quantity
-    for name in ["cappa", "dp1", "cvm"]:
+    for name in ["dp1", "cvm"]:
         quantity = quantity_factory.zeros(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             units="unknown",
@@ -89,7 +95,7 @@ def fvdyn_temporaries(quantity_factory: pace.util.QuantityFactory):
 def log_on_rank_0(msg: str):
     """Print when rank is 0 - outside of DaCe critical path"""
     if not MPI or MPI.COMM_WORLD.Get_rank() == 0:
-        print(msg)
+        logger.info(msg)
 
 
 class DynamicalCore:
@@ -106,6 +112,7 @@ class DynamicalCore:
         config: DynamicalCoreConfig,
         phis: pace.util.Quantity,
         state: DycoreState,
+        timestep: timedelta,
         checkpointer: Optional[pace.util.Checkpointer] = None,
     ):
         """
@@ -117,7 +124,8 @@ class DynamicalCore:
             config: configuration of dynamical core, for example as would be set by
                 the namelist in the Fortran model
             phis: surface geopotential height
-            state: Model state
+            state: model state
+            timestep: model timestep
             checkpointer: if given, used to perform operations on model data
                 at specific points in model execution, such as testing against
                 reference data
@@ -217,8 +225,12 @@ class DynamicalCore:
             name: quantity.storage for name, quantity in self.tracers.items()
         }
 
-        self._temporaries = fvdyn_temporaries(quantity_factory)
-        state.__dict__.update(self._temporaries)
+        temporaries = fvdyn_temporaries(quantity_factory)
+        self._te_2d = temporaries["te_2d"]
+        self._te0_2d = temporaries["te0_2d"]
+        self._wsd = temporaries["wsd"]
+        self._dp1 = temporaries["dp1"]
+        self._cvm = temporaries["cvm"]
 
         # Build advection stencils
         self.tracer_advection = tracer_2d_1l.TracerAdvection(
@@ -286,13 +298,8 @@ class DynamicalCore:
         self._cubed_to_latlon = CubedToLatLon(
             state, stencil_factory, grid_data, config.c2l_ord, comm
         )
+        self._cappa = self.acoustic_dynamics.cappa
 
-        self._temporaries = fvdyn_temporaries(quantity_factory)
-        # This is only here so the temporaries are attributes on this class,
-        # to more easily pick them up in unit testing
-        # if self._temporaries were a dataclass we can remove this
-        for name, value in self._temporaries.items():
-            setattr(self, f"_tmp_{name}", value)
         if not (not self.config.inline_q and NQ != 0):
             raise NotImplementedError("tracer_2d not implemented, turn on z_tracer")
         self._adjust_tracer_mixing_ratio = AdjustNegativeTracerMixingRatio(
@@ -320,6 +327,10 @@ class DynamicalCore:
         self._omega_halo_updater = WrappedHaloUpdater(
             comm.get_scalar_halo_updater([full_xyz_spec]), state, ["omga"], comm=comm
         )
+        self._n_split = config.n_split
+        self._k_split = config.k_split
+        self._conserve_total_energy = config.consv_te
+        self._timestep = timestep.total_seconds()
 
     def _checkpoint_fvdynamics(self, state: DycoreState, tag: str):
         if self.call_checkpointer:
@@ -336,40 +347,11 @@ class DynamicalCore:
                 qvapor=state.qvapor,
             )
 
-    def update_state(
+    def step_dynamics(
         self,
-        conserve_total_energy: float,
-        do_adiabatic_init: bool,
-        timestep: float,
-        n_split: int,
         state: DycoreState,
+        timer: Timer = pace.util.NullTimer(),
     ):
-        """
-        Args:
-            state: model dycore state
-            conserve_total_energy: if True, conserve total energy
-            do_adiabatic_init: if True, do adiabatic dynamics. Used
-                for model initialization.
-            timestep: time to progress forward in seconds
-            n_split: number of acoustic timesteps per remapping timestep
-        """
-        # TODO: state should be a statically typed class, move these to the
-        # definition of DycoreState and pass them on init or alternatively
-        # move these to/get these from the namelist/configuration class
-        state.__dict__.update(
-            {
-                "consv_te": conserve_total_energy,
-                "bdt": timestep,
-                "mdt": timestep / self.config.k_split,
-                "do_adiabatic_init": do_adiabatic_init,
-                "n_split": n_split,
-                "k_split": self.config.k_split,
-            }
-        )
-        state.__dict__.update(self._temporaries)
-        state.__dict__.update(self.acoustic_dynamics._temporaries)
-
-    def step_dynamics(self, state: DycoreState, timer: Timer = pace.util.NullTimer()):
         """
         Step the model state forward by one timestep.
 
@@ -381,7 +363,7 @@ class DynamicalCore:
         self._compute(state, timer)
         self._checkpoint_fvdynamics(state=state, tag="Out")
 
-    def compute_preamble(self, state, is_root_rank: bool):
+    def compute_preamble(self, state: DycoreState, is_root_rank: bool):
         if self.config.hydrostatic:
             raise NotImplementedError("Hydrostatic is not implemented")
         if __debug__:
@@ -394,19 +376,17 @@ class DynamicalCore:
             state.qice,
             state.qgraupel,
             state.q_con,
-            state.cvm,
+            self._cvm,
             state.pkz,
             state.pt,
-            state.cappa,
+            self._cappa,
             state.delp,
             state.delz,
-            state.dp1,
+            self._dp1,
         )
 
-        if state.consv_te > 0 and not state.do_adiabatic_init:
-            raise NotImplementedError(
-                "compute total energy is not implemented, it needs an allReduce"
-            )
+        if self._conserve_total_energy > 0:
+            raise NotImplementedError("compute total energy is not implemented")
 
         if (not self.config.rf_fast) and self.config.tau != 0:
             raise NotImplementedError(
@@ -422,7 +402,7 @@ class DynamicalCore:
                 log_on_rank_0("Adjust pt")
             self._pt_adjust_stencil(
                 state.pkz,
-                state.dp1,
+                self._dp1,
                 state.q_con,
                 state.pt,
             )
@@ -430,17 +410,25 @@ class DynamicalCore:
     def __call__(self, *args, **kwargs):
         return self.step_dynamics(*args, **kwargs)
 
-    def _compute(self, state, timer: pace.util.Timer):
+    def _compute(self, state: DycoreState, timer: pace.util.Timer):
         last_step = False
         self.compute_preamble(
             state,
             is_root_rank=self.comm_rank == 0,
         )
 
-        for k_split in dace_no_unroll(range(state.k_split)):
+        for k_split in dace_no_unroll(range(self._k_split)):
             n_map = k_split + 1
-            last_step = k_split == state.k_split - 1
-            self._dyn(state=state, tracers=self.tracers, n_map=n_map, timer=timer)
+            last_step = k_split == self._k_split - 1
+            self._dyn(
+                state=state,
+                cappa=self._cappa,
+                wsd=self._wsd,
+                tracers=self.tracers,
+                n_map=n_map,
+                timer=timer,
+                timestep=self._timestep / self._k_split,
+            )
 
             if self.grid_indexing.domain[2] > 4:
                 # nq is actually given by ncnst - pnats,
@@ -468,29 +456,28 @@ class DynamicalCore:
                         state.w,
                         state.ua,
                         state.va,
-                        state.cappa,
+                        self._cappa,
                         state.q_con,
                         state.qcld,
                         state.pkz,
                         state.pk,
                         state.pe,
                         state.phis,
-                        state.te0_2d,
+                        self._te0_2d,
                         state.ps,
-                        state.wsd,
+                        self._wsd,
                         state.omga,
                         self._ak,
                         self._bk,
                         self._pfull,
-                        state.dp1,
+                        self._dp1,
                         self._ptop,
                         constants.KAPPA,
                         constants.ZVIR,
                         last_step,
-                        state.consv_te,
-                        state.bdt / state.k_split,
-                        state.bdt,
-                        state.do_adiabatic_init,
+                        self._conserve_total_energy,
+                        self._timestep / self._k_split,
+                        self._timestep,
                     )
                 if last_step:
                     self.post_remap(
@@ -505,22 +492,26 @@ class DynamicalCore:
 
     def _dyn(
         self,
-        state,
+        state: DycoreState,
+        cappa: Quantity,
+        wsd: Quantity,
         tracers: Dict[str, Quantity],
         n_map,
+        timestep: float,  # time to step forward by
         timer: pace.util.Timer,
     ):
         self._copy_stencil(
             state.delp,
-            state.dp1,
+            self._dp1,
         )
         if __debug__:
             log_on_rank_0("DynCore")
         with timer.clock("DynCore"):
             self.acoustic_dynamics(
                 state,
+                wsd=wsd,
+                timestep=timestep,
                 n_map=n_map,
-                update_temporaries=False,
             )
         if self.config.z_tracer:
             if __debug__:
@@ -528,12 +519,12 @@ class DynamicalCore:
             with timer.clock("TracerAdvection"):
                 self.tracer_advection(
                     tracers,
-                    state.dp1,
+                    self._dp1,
                     state.mfxd,
                     state.mfyd,
                     state.cxd,
                     state.cyd,
-                    state.mdt,
+                    self._timestep / self._k_split,
                 )
 
     def post_remap(

--- a/fv3core/pace/fv3core/stencils/remapping.py
+++ b/fv3core/pace/fv3core/stencils/remapping.py
@@ -518,7 +518,6 @@ class LagrangianToEulerian:
         consv_te: float,
         mdt: float,
         bdt: float,
-        do_adiabatic_init: bool,
     ):
         """
         tracers (inout): Tracer species tracked across
@@ -554,7 +553,6 @@ class LagrangianToEulerian:
         consv_te (in): If True, conserve total energy
         mdt (in) : Remap time step
         bdt (in): Timestep
-        do_adiabatic_init (in): If True, do adiabatic dynamics
 
         Remap the deformed Lagrangian surfaces onto the reference, or "Eulerian",
         coordinate levels.
@@ -636,7 +634,7 @@ class LagrangianToEulerian:
 
         self._copy_from_below_stencil(ua, pe)
         dtmp = 0.0
-        if last_step and not do_adiabatic_init:
+        if last_step:
             if consv_te > CONSV_MIN:
                 raise NotImplementedError(
                     "We do not support consv_te > 0.001 "
@@ -652,7 +650,7 @@ class LagrangianToEulerian:
                 )
 
         if self._do_sat_adjust:
-            fast_mp_consv = not do_adiabatic_init and consv_te > CONSV_MIN
+            fast_mp_consv = consv_te > CONSV_MIN
             self._saturation_adjustment(
                 dp1,
                 tracers["qvapor"],

--- a/fv3core/pace/fv3core/testing/translate_dyncore.py
+++ b/fv3core/pace/fv3core/testing/translate_dyncore.py
@@ -148,7 +148,7 @@ class TranslateDynCore(ParallelTranslate2PyState):
             grid_data.ks = inputs["ks"]
         self._base.make_storage_data_input_vars(inputs)
         state = DycoreState.init_zeros(quantity_factory=self.grid.quantity_factory)
-        wsd = self.grid.quantity_factory.empty(
+        wsd: pace.util.Quantity = self.grid.quantity_factory.empty(
             dims=[pace.util.X_DIM, pace.util.Y_DIM],
             units="unknown",
         )
@@ -173,11 +173,11 @@ class TranslateDynCore(ParallelTranslate2PyState):
             phis=inputs["phis"],
             state=state,
         )
-        acoustic_dynamics.cappa.data[:] = inputs["cappa"][:]
+        acoustic_dynamics.cappa.data = inputs["cappa"]
 
         acoustic_dynamics(state, wsd=wsd, timestep=inputs["mdt"], n_map=state.n_map)
-        inputs["cappa"][:] = acoustic_dynamics.cappa.data[:]
-        inputs["wsd"][:] = wsd.data[:]
+        inputs["cappa"] = acoustic_dynamics.cappa.data
+        inputs["wsd"] = wsd
         storages_only = {}
         for name, value in vars(state).items():
             if isinstance(value, pace.util.Quantity):

--- a/fv3core/pace/fv3core/testing/translate_dyncore.py
+++ b/fv3core/pace/fv3core/testing/translate_dyncore.py
@@ -173,10 +173,10 @@ class TranslateDynCore(ParallelTranslate2PyState):
             phis=inputs["phis"],
             state=state,
         )
-        acoustic_dynamics.cappa.data = inputs["cappa"]
+        acoustic_dynamics.cappa._data = inputs["cappa"]
 
         acoustic_dynamics(state, wsd=wsd, timestep=inputs["mdt"], n_map=state.n_map)
-        inputs["cappa"] = acoustic_dynamics.cappa.data
+        inputs["cappa"] = acoustic_dynamics.cappa._data
         inputs["wsd"] = wsd
         storages_only = {}
         for name, value in vars(state).items():

--- a/fv3core/pace/fv3core/testing/translate_dyncore.py
+++ b/fv3core/pace/fv3core/testing/translate_dyncore.py
@@ -173,10 +173,10 @@ class TranslateDynCore(ParallelTranslate2PyState):
             phis=inputs["phis"],
             state=state,
         )
-        acoustic_dynamics.cappa._data = inputs["cappa"]
+        acoustic_dynamics.cappa.storage[:] = inputs["cappa"][:]
 
         acoustic_dynamics(state, wsd=wsd, timestep=inputs["mdt"], n_map=state.n_map)
-        inputs["cappa"] = acoustic_dynamics.cappa._data
+        inputs["cappa"][:] = acoustic_dynamics.cappa.storage[:]
         inputs["wsd"] = wsd
         storages_only = {}
         for name, value in vars(state).items():

--- a/fv3core/pace/fv3core/testing/translate_dyncore.py
+++ b/fv3core/pace/fv3core/testing/translate_dyncore.py
@@ -148,8 +148,8 @@ class TranslateDynCore(ParallelTranslate2PyState):
             grid_data.ks = inputs["ks"]
         self._base.make_storage_data_input_vars(inputs)
         state = DycoreState.init_zeros(quantity_factory=self.grid.quantity_factory)
-        state.cappa = self.grid.quantity_factory.empty(
-            dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
+        wsd = self.grid.quantity_factory.empty(
+            dims=[pace.util.X_DIM, pace.util.Y_DIM],
             units="unknown",
         )
         for name, value in inputs.items():
@@ -173,8 +173,11 @@ class TranslateDynCore(ParallelTranslate2PyState):
             phis=inputs["phis"],
             state=state,
         )
-        state.__dict__.update(acoustic_dynamics._temporaries)
-        acoustic_dynamics(state, n_map=state.n_map, update_temporaries=False)
+        acoustic_dynamics.cappa.data[:] = inputs["cappa"][:]
+
+        acoustic_dynamics(state, wsd=wsd, timestep=inputs["mdt"], n_map=state.n_map)
+        inputs["cappa"][:] = acoustic_dynamics.cappa.data[:]
+        inputs["wsd"][:] = wsd.data[:]
         storages_only = {}
         for name, value in vars(state).items():
             if isinstance(value, pace.util.Quantity):

--- a/fv3core/pace/fv3core/testing/translate_dyncore.py
+++ b/fv3core/pace/fv3core/testing/translate_dyncore.py
@@ -176,12 +176,14 @@ class TranslateDynCore(ParallelTranslate2PyState):
         acoustic_dynamics.cappa.storage[:] = inputs["cappa"][:]
 
         acoustic_dynamics(state, wsd=wsd, timestep=inputs["mdt"], n_map=state.n_map)
-        inputs["cappa"][:] = acoustic_dynamics.cappa.storage[:]
-        inputs["wsd"] = wsd
+        # the "inputs" dict is not used to return, we construct a new dict based
+        # on variables attached to `state`
         storages_only = {}
         for name, value in vars(state).items():
             if isinstance(value, pace.util.Quantity):
                 storages_only[name] = value.storage
             else:
                 storages_only[name] = value
+        storages_only["wsd"] = wsd.storage
+        storages_only["cappa"] = acoustic_dynamics.cappa.storage
         return self._base.slice_output(storages_only)

--- a/fv3core/pace/fv3core/testing/translate_fvdynamics.py
+++ b/fv3core/pace/fv3core/testing/translate_fvdynamics.py
@@ -1,4 +1,5 @@
 from dataclasses import fields
+from datetime import timedelta
 from typing import Any, Dict, Optional, Tuple
 
 import pytest
@@ -209,7 +210,6 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
             "dims": [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             "units": "Pa/s",
         },
-        "do_adiabatic_init": {"dims": []},
         "bdt": {"dims": []},
         "ptop": {"dims": []},
         "ks": {"dims": []},
@@ -217,7 +217,7 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
 
     outputs = inputs.copy()
 
-    for name in ("do_adiabatic_init", "bdt", "ak", "bk", "ks", "ptop"):
+    for name in ("bdt", "ak", "bk", "ks", "ptop"):
         outputs.pop(name)
 
     def __init__(
@@ -336,13 +336,7 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
             config=DynamicalCoreConfig.from_namelist(self.namelist),
             phis=state.phis,
             state=state,
-        )
-        self.dycore.update_state(
-            self.namelist.consv_te,
-            inputs["do_adiabatic_init"],
-            inputs["bdt"],
-            self.namelist.n_split,
-            state,
+            timestep=timedelta(seconds=inputs["bdt"]),
         )
         self.dycore.step_dynamics(state, pace.util.NullTimer())
         outputs = self.outputs_from_state(state)

--- a/fv3core/tests/mpi/test_doubly_periodic.py
+++ b/fv3core/tests/mpi/test_doubly_periodic.py
@@ -111,14 +111,12 @@ def setup_dycore() -> Tuple[fv3core.DynamicalCore, List[Any]]:
         phis=state.phis,
         state=state,
     )
-    do_adiabatic_init = False
     # TODO compute from namelist
     bdt = config.dt_atmos
 
     args = [
         state,
         config.consv_te,
-        do_adiabatic_init,
         bdt,
         config.n_split,
     ]

--- a/fv3core/tests/savepoint/translate/translate_remapping.py
+++ b/fv3core/tests/savepoint/translate/translate_remapping.py
@@ -82,7 +82,6 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
             "consv_te",
             "mdt",
             "bdt",
-            "do_adiabatic_init",
             "nq",
         ]
         self.out_vars = {}

--- a/tests/main/fv3core/test_dycore_call.py
+++ b/tests/main/fv3core/test_dycore_call.py
@@ -124,15 +124,6 @@ def setup_dycore() -> Tuple[
         phis=state.phis,
         state=state,
     )
-    do_adiabatic_init = False
-
-    dycore.update_state(
-        config.consv_te,
-        do_adiabatic_init,
-        config.dt_atmos,
-        config.n_split,
-        state,
-    )
 
     return dycore, state, pace.util.NullTimer()
 

--- a/tests/main/fv3core/test_dycore_call.py
+++ b/tests/main/fv3core/test_dycore_call.py
@@ -1,6 +1,7 @@
 import os
 import unittest.mock
 from dataclasses import fields
+from datetime import timedelta
 from typing import Tuple
 
 import pace.dsl.stencil
@@ -121,6 +122,7 @@ def setup_dycore() -> Tuple[
         stencil_factory=stencil_factory,
         damping_coefficients=DampingCoefficients.new_from_metric_terms(metric_terms),
         config=config,
+        timestep=timedelta(seconds=config.dt_atmos),
         phis=state.phis,
         state=state,
     )

--- a/tests/mpi/test_checkpoints.py
+++ b/tests/mpi/test_checkpoints.py
@@ -37,41 +37,13 @@ class StateInitializer:
         self,
         ds: xr.Dataset,
         translate: TranslateFVDynamics,
-        communicator,
-        stencil_factory,
-        grid,
-        dycore_config,
-        consv_te,
-        n_split,
     ):
         self._ds = ds
         self._translate = translate
-        self._consv_te = consv_te
-        self._n_split = n_split
-
-        input_data = dataset_to_dict(self._ds.copy())
-        state, grid_data = self._translate.prepare_data(input_data)
-        self._dycore = fv3core.DynamicalCore(
-            comm=communicator,
-            grid_data=grid_data,
-            stencil_factory=stencil_factory,
-            damping_coefficients=grid.damping_coefficients,
-            config=dycore_config,
-            phis=state.phis,
-            state=state,
-        )
 
     def new_state(self) -> Tuple[DycoreState, GridData]:
         input_data = dataset_to_dict(self._ds.copy())
         state, grid_data = self._translate.prepare_data(input_data)
-
-        self._dycore.update_state(
-            self._consv_te,
-            input_data["do_adiabatic_init"],
-            input_data["bdt"],
-            self._n_split,
-            state,
-        )
         return state, grid_data
 
 
@@ -127,12 +99,6 @@ def test_fv_dynamics(
     initializer = StateInitializer(
         ds,
         translate,
-        communicator,
-        stencil_factory,
-        grid,
-        dycore_config,
-        namelist.consv_te,
-        namelist.n_split,
     )
     print("stencils initialized")
     if calibrate_thresholds:


### PR DESCRIPTION
## Purpose

Currently, temporary variables are attached to DycoreState at call time, preventing us from type hinting DycoreState and making it difficult to reason about data flow. This PR removes these temporaries from DycoreState, instead treating them like other internal temporaries of the model.

## Code changes:

- DynamicalCore.update_state is removed
- DynamicalCore now requires a timestep on initialization
- do_adiabatic_init is fully removed from Pace, as only False is supported
- Call signature of DynamicalCore is updated
- log_on_rank_0 in fv_dynamics.py is updated to use `logger.info` instead of `print`

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
