### PR TITLE
Run test_driver on large resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ jobs:
   test_driver:
     docker:
       - image: cimg/python:3.8
+    resource_class: large
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
## Purpose

Currently we are experiencing intermittent failures of `test_driver` on CircleCI, and are hitting CPU caps on the machine. This PR updates the resource class for that job from medium to large to increase CPU availability.

## Infrastructure changes:

- updated resource class for CircleCI test_driver job to `large`

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
