### PR TITLE
Fix caching of gt4py caches in 54rank test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,23 +128,20 @@ jobs:
           keys:
             - v3-gt_cache_54ranks-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
             - v2-savepoints-c12_54ranks_standard-{{ checksum "Makefile.data_download" }}
-            - v2-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+            - v3-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
       - run:
           name: set up environment
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
             pip3 install --upgrade setuptools wheel
             pip3 install -r requirements_dev.txt -c constraints.txt
       - save_cache:
-          key: v2-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+          key: v3-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
           paths:
             - /home/circleci/.cache/pip
-            - venv
+            - /opt/circleci/.pyenv/versions
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
             GT_CACHE_ROOT=".gt_cache" TEST_ARGS="--backend=<<parameters.backend>> -v -s" CONTAINER_CMD="" NUM_RANKS=54 EXPERIMENT="c12_54ranks_standard" FV3_PATH=$(pwd)/fv3core make savepoint_tests_mpi
           no_output_timeout: 3h
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
   savepoints_mpi:
     machine:
       image: ubuntu-2004:202111-02
-      resource_class: medium+
+      resource_class: large
     parameters:
       backend:
         description: "gt4py backend"
@@ -126,7 +126,7 @@ jobs:
           command: git submodule status external/gt4py | awk '{print $1;}' > gt4py_version.txt
       - restore_cache:
           keys:
-            - v2-gt_cache_54ranks-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+            - v3-gt_cache_54ranks-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
             - v2-savepoints-c12_54ranks_standard-{{ checksum "Makefile.data_download" }}
             - v2-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
       - run:
@@ -141,10 +141,10 @@ jobs:
       - run:
           name: run tests
           command: |
-            GT_CACHE_DIR_ROOT=".gt_cache" TEST_ARGS="--backend=<<parameters.backend>> -v -s" CONTAINER_CMD="" NUM_RANKS=54 EXPERIMENT="c12_54ranks_standard" FV3_PATH=$(pwd)/fv3core make savepoint_tests_mpi
+            GT_CACHE_ROOT=".gt_cache" TEST_ARGS="--backend=<<parameters.backend>> -v -s" CONTAINER_CMD="" NUM_RANKS=54 EXPERIMENT="c12_54ranks_standard" FV3_PATH=$(pwd)/fv3core make savepoint_tests_mpi
           no_output_timeout: 3h
       - save_cache:
-          key: v2-gt_cache_54ranks-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+          key: v3-gt_cache_54ranks-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
           paths:
             - .gt_cache
       - save_cache:
@@ -192,7 +192,7 @@ jobs:
   test_driver:
     docker:
       - image: cimg/python:3.8
-    resource_class: medium+
+    resource_class: large
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,15 +132,19 @@ jobs:
       - run:
           name: set up environment
           command: |
+            python3 -m venv venv
+            . venv/bin/activate
             pip3 install --upgrade setuptools wheel
             pip3 install -r requirements_dev.txt -c constraints.txt
       - save_cache:
           key: v2-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
           paths:
             - /home/circleci/.cache/pip
+            - venv
       - run:
           name: run tests
           command: |
+            . venv/bin/activate
             GT_CACHE_ROOT=".gt_cache" TEST_ARGS="--backend=<<parameters.backend>> -v -s" CONTAINER_CMD="" NUM_RANKS=54 EXPERIMENT="c12_54ranks_standard" FV3_PATH=$(pwd)/fv3core make savepoint_tests_mpi
           no_output_timeout: 3h
       - save_cache:

--- a/dsl/pace/dsl/__init__.py
+++ b/dsl/pace/dsl/__init__.py
@@ -17,7 +17,6 @@ from .stencil import (
 if MPI is not None:
     import os
 
-    gt4py.config.cache_settings["root_path"] = os.environ.get("GT_CACHE_DIR_NAME", ".")
     gt4py.config.cache_settings["dir_name"] = os.environ.get(
-        "GT_CACHE_ROOT", f".gt_cache_{MPI.COMM_WORLD.Get_rank():06}"
+        "GT_CACHE_DIR_NAME", f".gt_cache_{MPI.COMM_WORLD.Get_rank():06}"
     )


### PR DESCRIPTION
## Purpose

CircleCI caching of gt4py caches was not appropriately set up in #255 . This PR configures it correctly.

## Infrastructure changes:

- Configured caching of gt4py caches for 54rank CircleCI translate tests
- corrected CircleCI machine types from non-existent "medium+" to "large"

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
