### PR TITLE
Fix run_standalone execution

### DIFF
--- a/fv3core/examples/standalone/runfile/dynamics.py
+++ b/fv3core/examples/standalone/runfile/dynamics.py
@@ -3,7 +3,7 @@
 import copy
 import json
 from argparse import ArgumentParser, Namespace
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Tuple
 
 import f90nml
@@ -263,6 +263,7 @@ def setup_dycore(
         config=dycore_config,
         phis=state.phis,
         state=state,
+        timestep=timedelta(seconds=dycore_config.dt_atmos),
     )
     return dycore, state, stencil_factory
 


### PR DESCRIPTION
## Purpose

PR #308 broke the run_standalone execution since DynamicalCore's initialization API changed, but its runfiles weren't updated. This PR updates them to restore the functionality of the compilation and performance plans on daint.

## Infrastructure changes:

- Fix run_standalone runfiles to work with DynamicalCore's new initialization API

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

