### PR TITLE
Feature/transform grid stretch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,3 @@ RESTART/
 _dacegraphs
 
 **/testing/output/*
-
-*nc
-*png

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ RESTART/
 _dacegraphs
 
 **/testing/output/*
+
+*nc
+*png

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -27,9 +27,9 @@ from pace.util.communicator import CubedSphereCommunicator
 
 from . import diagnostics
 from .comm import CreatesCommSelector
+from .gridconfig import GridConfig
 from .initialization import InitializerSelector
 from .performance import PerformanceConfig
-from .gridconfig import GridConfig
 
 
 logger = logging.getLogger(__name__)
@@ -95,10 +95,8 @@ class DriverConfig:
     physics_config: pace.physics.PhysicsConfig = dataclasses.field(
         default_factory=pace.physics.PhysicsConfig
     )
-    grid_config: GridConfig = dataclasses.field(
-        default_factory=GridConfig
-    )
-    
+    grid_config: GridConfig = dataclasses.field(default_factory=GridConfig)
+
     days: int = 0
     hours: int = 0
     minutes: int = 0

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -29,6 +29,7 @@ from . import diagnostics
 from .comm import CreatesCommSelector
 from .initialization import InitializerSelector
 from .performance import PerformanceConfig
+from .gridconfig import GridConfig
 
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,10 @@ class DriverConfig:
     physics_config: pace.physics.PhysicsConfig = dataclasses.field(
         default_factory=pace.physics.PhysicsConfig
     )
+    grid_config: GridConfig = dataclasses.field(
+        default_factory=GridConfig
+    )
+    
     days: int = 0
     hours: int = 0
     minutes: int = 0

--- a/driver/pace/driver/gridconfig.py
+++ b/driver/pace/driver/gridconfig.py
@@ -7,9 +7,9 @@ import numpy as np
 @dataclasses.dataclass
 class GridConfig:
     stretch_mode: bool = False
-    stretch_factor: Optional[np.float_] = 1.0
-    lon_target: Optional[np.float_] = 0.0
-    lat_target: Optional[np.float_] = 0.0
+    stretch_factor: Optional[np.float_] = None
+    lon_target: Optional[np.float_] = None
+    lat_target: Optional[np.float_] = None
 
     def __post_init__(self):
         if self.stretch_mode:

--- a/driver/pace/driver/gridconfig.py
+++ b/driver/pace/driver/gridconfig.py
@@ -1,12 +1,8 @@
 import dataclasses
-import os.path
-import subprocess
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 
-from .report import collect_data_and_write_to_file
-from pace.util import Namelist
 
 @dataclasses.dataclass
 class GridConfig:
@@ -18,7 +14,9 @@ class GridConfig:
     def __post_init__(self):
         if self.stretch_mode:
             if not self.stretch_factor:
-                raise ValueError("Stretch_mode is true, but no stretch_factor is provided.")
+                raise ValueError(
+                    "Stretch_mode is true, but no stretch_factor is provided."
+                )
             if not self.lon_target:
                 raise ValueError("Stretch_mode is true, but no lon_target is provided.")
             if not self.lat_target:

--- a/driver/pace/driver/gridconfig.py
+++ b/driver/pace/driver/gridconfig.py
@@ -1,0 +1,25 @@
+import dataclasses
+import os.path
+import subprocess
+from typing import List, Optional
+
+import numpy as np
+
+from .report import collect_data_and_write_to_file
+from pace.util import Namelist
+
+@dataclasses.dataclass
+class GridConfig:
+    stretch_mode: bool = False
+    stretch_factor: Optional[np.float_] = 1.0
+    lon_target: Optional[np.float_] = 0.0
+    lat_target: Optional[np.float_] = 0.0
+
+    def __post_init__(self):
+        if self.stretch_mode:
+            if not self.stretch_factor:
+                raise ValueError("Stretch_mode is true, but no stretch_factor is provided.")
+            if not self.lon_target:
+                raise ValueError("Stretch_mode is true, but no lon_target is provided.")
+            if not self.lat_target:
+                raise ValueError("Stretch_mode is true, but no lat_target is provided.")

--- a/tests/main/driver/test_driver.py
+++ b/tests/main/driver/test_driver.py
@@ -48,6 +48,7 @@ def get_driver_config(
         layout=layout,
         initialization=initialization_config,
         performance_config=unittest.mock.MagicMock(),
+        grid_config=unittest.mock.MagicMock(),
         comm_config=NullCommConfig(layout),
         diagnostics_config=unittest.mock.MagicMock(
             output_frequency=frequency, output_initial_state=output_initial_state

--- a/util/HISTORY.md
+++ b/util/HISTORY.md
@@ -4,6 +4,8 @@ History
 latest
 ------
 
+
+
 Major changes:
 - Added the following attributes/methods to Communicator: `tile`, `halo_update`, `boundaries`, `start_halo_update`, `vector_halo_update`, `start_vector_halo_update`, `synchronize_vector_interfaces`, `start_synchronize_vector_interfaces`, `get_scalar_halo_updater`, and `get_vector_halo_updater`
 - Added Checkpointer and NullCheckpointer classes
@@ -19,6 +21,7 @@ Minor changes:
 Minor changes:
 - Fixed a bug in normalize_vector(xyz) in `pace.util.grid.gnomonic` where it would divide the input by cells-per-tile, where it should not.
 - Refactored `pace.util.grid.helper` so that `HorizontalGridData`, `VerticalGridData`, `ContravariantGridData` and `AngleGridData` have their own `new_from_metric_terms` class methods, and `GridData` calls those in its own method definition.
+- Added `stretch_transformation` to `pace.util.grid` - stretches the grid as needed for refinement, tropical test case.
 
 v0.9.0
 ------

--- a/util/pace/util/grid/__init__.py
+++ b/util/pace/util/grid/__init__.py
@@ -20,5 +20,4 @@ from .helper import (
     HorizontalGridData,
     VerticalGridData,
 )
-
 from .stretch_transformation import direct_transform

--- a/util/pace/util/grid/__init__.py
+++ b/util/pace/util/grid/__init__.py
@@ -20,3 +20,5 @@ from .helper import (
     HorizontalGridData,
     VerticalGridData,
 )
+
+from .stretch_transformation import direct_transform

--- a/util/pace/util/grid/stretch_transformation.py
+++ b/util/pace/util/grid/stretch_transformation.py
@@ -1,4 +1,4 @@
-import copy as cp
+import copy
 from typing import Tuple, Union
 
 import numpy as np
@@ -8,11 +8,11 @@ from pace.util import Quantity
 
 def direct_transform(
     *,
-    lon: Quantity,
-    lat: Quantity,
-    stretch_factor: float,
-    lon_target: float,
-    lat_target: float,
+    lon: Union[Quantity, np.ndarray],
+    lat: Union[Quantity, np.ndarray],
+    stretch_factor: np.float_,
+    lon_target: np.float_,
+    lat_target: np.float_,
 ) -> Tuple[Union[np.ndarray, Quantity], Union[np.ndarray, Quantity]]:
     """
     The direct_transform subroutine from fv_grid_utils.F90.
@@ -21,17 +21,17 @@ def direct_transform(
     Then performs translation of all tiles so that the now-smaller tile 6 is
     centeres on lon_target, lat_target.
 
-    Inputs:
-    - lon in radians
-    - lat in radians
-    - stretch_factor (e.g. 3.0 means that the resolution on
-        tile 6 becomes 3 times as fine)
-    - lon_target in degrees (from namelist)
-    - lat_target in degrees (from namelist)
+    Args:
+        lon (in) in radians
+        lat (in) in radians
+        stretch_factor (in) stretch_factor (e.g. 3.0 means that the resolution on
+            tile 6 becomes 3 times as fine)
+        lon_target (in) in degrees (from namelist)
+        lat_target (in) in degrees (from namelist)
 
-    Outputs:
-    - lon_transform in radians
-    - lat_transform in radians
+    Returns:
+        lon_transform (out) in radians
+        lat_transform (out) in radians
     """
 
     if isinstance(lon, Quantity):
@@ -40,6 +40,8 @@ def direct_transform(
     elif isinstance(lon, np.ndarray):
         lon_data = lon
         lat_data = lat
+    else:
+        raise Exception("Input data type not supported.")
 
     lon_p, lat_p = np.deg2rad(lon_target), np.deg2rad(lat_target)
     sin_p, cos_p = np.sin(lat_p), np.cos(lat_p)
@@ -82,8 +84,8 @@ def direct_transform(
     lon_trans[lon_trans >= 2 * np.pi] -= 2 * np.pi
 
     if isinstance(lon, Quantity):
-        lon_transform = cp.deepcopy(lon)
-        lat_transform = cp.deepcopy(lat)
+        lon_transform = copy.deepcopy(lon)
+        lat_transform = copy.deepcopy(lat)
 
         lon_transform.data[:] = lon_trans
         lat_transform.data[:] = lat_trans
@@ -102,9 +104,11 @@ def _sign(input, pn):
 
     Takes the sign of pn (positive or negative) and assigns it to value.
 
-    Inputs:
-    - input: value to be assigned a sign
-    - pn: value whose sign is assigned to input
+    Args:
+        input (in): value to be assigned a sign
+        pn (in): value whose sign is assigned to input
+    Returns:
+        output (out): value with assigned sign based on pn
     """
     if isinstance(input, float) and isinstance(pn, float):
         output = np.nan

--- a/util/pace/util/grid/stretch_transformation.py
+++ b/util/pace/util/grid/stretch_transformation.py
@@ -1,0 +1,118 @@
+import copy as cp
+import numpy as np
+
+from typing import Tuple, Union
+
+from pace.util import Quantity
+
+def direct_transform(*, lon: Quantity, lat: Quantity, stretch_factor: float, lon_target: float, lat_target:float) -> Tuple[Union[np.ndarray, Quantity], Union[np.ndarray, Quantity]]:
+    """
+    The direct_transform subroutine from fv_grid_utils.F90.
+    Takes in latitude and longitude in radians. 
+    Shrinks tile 6 by stretch factor in area to increse resolution locally.
+    Then performs translation of all tiles so that the now-smaller tile 6 is
+    centeres on lon_target, lat_target.
+
+    Inputs:
+    - lon in radians
+    - lat in radians
+    - stretch_factor (e.g. 3.0 means that the resolution on 
+        tile 6 becomes 3 times as fine)
+    - lon_target in degrees (from namelist)
+    - lat_target in degrees (from namelist)
+
+    Outputs:
+    - lon_transform in radians
+    - lat_transform in radians
+    """
+
+    if isinstance(lon, Quantity):
+        lon_data = lon.data
+        lat_data = lat.data
+    elif isinstance(lon, np.ndarray):
+        lon_data = lon
+        lat_data = lat
+
+    lon_p, lat_p = np.deg2rad(lon_target), np.deg2rad(lat_target)
+    sin_p, cos_p = np.sin(lat_p), np.cos(lat_p)
+    c2p1 = 1. + stretch_factor**2
+    c2m1 = 1. - stretch_factor**2
+
+
+    # # first limit longitude so it's between 0 and 2pi
+    lon_data[lon_data < 0] += 2 * np.pi
+    lon_data[lon_data >= 2 * np.pi] -= 2 * np.pi
+
+    if np.abs(c2m1) > 1e-7: # do stretching
+        lat_t = np.arcsin((c2m1 + c2p1*np.sin(lat_data)) / (c2p1 + c2m1*np.sin(lat_data)))
+        lon_t = lon_data
+    else: # no stretching
+        lat_t = lat_data
+        lon_t = lon_data
+    
+    sin_lat = np.sin(lat_t)
+    cos_lat = np.cos(lat_t)
+    
+    sin_o = - (sin_p * sin_lat + cos_p * cos_lat * np.cos(lon_data))
+    tmp = 1 - np.abs(sin_o)
+
+
+    lon_trans = np.zeros(lon_data.shape) * np.nan
+    lat_trans = np.zeros(lat_data.shape) * np.nan
+
+    lon_trans[tmp < 1e-7] = 0.
+    lat_trans[tmp < 1e-7] = _sign(np.pi / 2, sin_o[tmp < 1e-7])
+
+    lon_trans[tmp >= 1e-7] = lon_p + np.arctan2(-np.cos(lat_t[tmp >= 1e-7]) * np.sin(lon[tmp >= 1e-7]), -np.sin(lat_t[tmp >= 1e-7])*np.cos(lat_p) + np.cos(lat_t[tmp >= 1e-7]) * np.sin(lat_p) * np.cos(lon[tmp >= 1e-7]))
+    lat_trans[tmp >= 1e-7] = np.arcsin(sin_o[tmp >= 1e-7])
+
+    lon_trans[lon_trans < 0] += 2 * np.pi
+    lon_trans[lon_trans >= 2 * np.pi] -= 2 * np.pi
+
+    if isinstance(lon, Quantity):
+        lon_transform = cp.deepcopy(lon)
+        lat_transform = cp.deepcopy(lat)
+
+        lon_transform.data[:] = lon_trans
+        lat_transform.data[:] = lat_trans
+
+    elif isinstance(lon, np.ndarray):
+        lon_transform = lon_trans
+        lat_transform = lat_trans
+
+    return lon_transform, lat_transform
+
+
+
+def _sign(input, pn):
+    """
+    Use:
+    output = sign(input, pn)
+
+    Takes the sign of pn (positive or negative) and assigns it to value.
+
+    Inputs:
+    - input: value to be assigned a sign
+    - pn: value whose sign is assigned to input
+    """
+    if isinstance(input, float) and isinstance(pn, float):
+        output = np.nan
+        
+        if pn >= 0:
+            output = np.abs(input)
+        else:
+            output = - np.abs(input)
+    
+    elif isinstance(input, np.ndarray):
+        tmp = np.abs(input)
+        output = np.zeros(input.shape) * np.nan
+        output[pn >= 0] = tmp[pn >= 0]
+        output[pn < 0] = - tmp[pn < 0]
+    
+    elif isinstance(pn, np.ndarray) and isinstance(input, float):
+        tmp = np.abs(input)
+        output = np.zeros(pn.shape) * np.nan
+        output[pn >= 0] = tmp
+        output[pn < 0] = - tmp
+
+    return output

--- a/util/pace/util/grid/stretch_transformation.py
+++ b/util/pace/util/grid/stretch_transformation.py
@@ -1,14 +1,22 @@
 import copy as cp
-import numpy as np
-
 from typing import Tuple, Union
+
+import numpy as np
 
 from pace.util import Quantity
 
-def direct_transform(*, lon: Quantity, lat: Quantity, stretch_factor: float, lon_target: float, lat_target:float) -> Tuple[Union[np.ndarray, Quantity], Union[np.ndarray, Quantity]]:
+
+def direct_transform(
+    *,
+    lon: Quantity,
+    lat: Quantity,
+    stretch_factor: float,
+    lon_target: float,
+    lat_target: float,
+) -> Tuple[Union[np.ndarray, Quantity], Union[np.ndarray, Quantity]]:
     """
     The direct_transform subroutine from fv_grid_utils.F90.
-    Takes in latitude and longitude in radians. 
+    Takes in latitude and longitude in radians.
     Shrinks tile 6 by stretch factor in area to increse resolution locally.
     Then performs translation of all tiles so that the now-smaller tile 6 is
     centeres on lon_target, lat_target.
@@ -16,7 +24,7 @@ def direct_transform(*, lon: Quantity, lat: Quantity, stretch_factor: float, lon
     Inputs:
     - lon in radians
     - lat in radians
-    - stretch_factor (e.g. 3.0 means that the resolution on 
+    - stretch_factor (e.g. 3.0 means that the resolution on
         tile 6 becomes 3 times as fine)
     - lon_target in degrees (from namelist)
     - lat_target in degrees (from namelist)
@@ -35,33 +43,39 @@ def direct_transform(*, lon: Quantity, lat: Quantity, stretch_factor: float, lon
 
     lon_p, lat_p = np.deg2rad(lon_target), np.deg2rad(lat_target)
     sin_p, cos_p = np.sin(lat_p), np.cos(lat_p)
-    c2p1 = 1. + stretch_factor**2
-    c2m1 = 1. - stretch_factor**2
+    c2p1 = 1.0 + stretch_factor ** 2
+    c2m1 = 1.0 - stretch_factor ** 2
 
     # first limit longitude so it's between 0 and 2pi
     lon_data[lon_data < 0] += 2 * np.pi
     lon_data[lon_data >= 2 * np.pi] -= 2 * np.pi
 
-    if np.abs(c2m1) > 1e-7: # do stretching
-        lat_t = np.arcsin((c2m1 + c2p1*np.sin(lat_data)) / (c2p1 + c2m1*np.sin(lat_data)))
+    if np.abs(c2m1) > 1e-7:  # do stretching
+        lat_t = np.arcsin(
+            (c2m1 + c2p1 * np.sin(lat_data)) / (c2p1 + c2m1 * np.sin(lat_data))
+        )
         lon_t = lon_data
-    else: # no stretching
+    else:  # no stretching
         lat_t = lat_data
         lon_t = lon_data
-    
+
     sin_lat = np.sin(lat_t)
     cos_lat = np.cos(lat_t)
-    
-    sin_o = - (sin_p * sin_lat + cos_p * cos_lat * np.cos(lon_data))
+
+    sin_o = -(sin_p * sin_lat + cos_p * cos_lat * np.cos(lon_data))
     tmp = 1 - np.abs(sin_o)
 
     lon_trans = np.zeros(lon_data.shape) * np.nan
     lat_trans = np.zeros(lat_data.shape) * np.nan
 
-    lon_trans[tmp < 1e-7] = 0.
+    lon_trans[tmp < 1e-7] = 0.0
     lat_trans[tmp < 1e-7] = _sign(np.pi / 2, sin_o[tmp < 1e-7])
 
-    lon_trans[tmp >= 1e-7] = lon_p + np.arctan2(-np.cos(lat_t[tmp >= 1e-7]) * np.sin(lon_data[tmp >= 1e-7]), -np.sin(lat_t[tmp >= 1e-7])*np.cos(lat_p) + np.cos(lat_t[tmp >= 1e-7]) * np.sin(lat_p) * np.cos(lon_data[tmp >= 1e-7]))
+    lon_trans[tmp >= 1e-7] = lon_p + np.arctan2(
+        -np.cos(lat_t[tmp >= 1e-7]) * np.sin(lon_data[tmp >= 1e-7]),
+        -np.sin(lat_t[tmp >= 1e-7]) * np.cos(lat_p)
+        + np.cos(lat_t[tmp >= 1e-7]) * np.sin(lat_p) * np.cos(lon_data[tmp >= 1e-7]),
+    )
     lat_trans[tmp >= 1e-7] = np.arcsin(sin_o[tmp >= 1e-7])
 
     lon_trans[lon_trans < 0] += 2 * np.pi
@@ -81,7 +95,6 @@ def direct_transform(*, lon: Quantity, lat: Quantity, stretch_factor: float, lon
     return lon_transform, lat_transform
 
 
-
 def _sign(input, pn):
     """
     Use:
@@ -95,22 +108,22 @@ def _sign(input, pn):
     """
     if isinstance(input, float) and isinstance(pn, float):
         output = np.nan
-        
+
         if pn >= 0:
             output = np.abs(input)
         else:
-            output = - np.abs(input)
-    
+            output = -np.abs(input)
+
     elif isinstance(input, np.ndarray):
         tmp = np.abs(input)
         output = np.zeros(input.shape) * np.nan
         output[pn >= 0] = tmp[pn >= 0]
-        output[pn < 0] = - tmp[pn < 0]
-    
+        output[pn < 0] = -tmp[pn < 0]
+
     elif isinstance(pn, np.ndarray) and isinstance(input, float):
         tmp = np.abs(input)
         output = np.zeros(pn.shape) * np.nan
         output[pn >= 0] = tmp
-        output[pn < 0] = - tmp
+        output[pn < 0] = -tmp
 
     return output

--- a/util/pace/util/grid/stretch_transformation.py
+++ b/util/pace/util/grid/stretch_transformation.py
@@ -38,8 +38,7 @@ def direct_transform(*, lon: Quantity, lat: Quantity, stretch_factor: float, lon
     c2p1 = 1. + stretch_factor**2
     c2m1 = 1. - stretch_factor**2
 
-
-    # # first limit longitude so it's between 0 and 2pi
+    # first limit longitude so it's between 0 and 2pi
     lon_data[lon_data < 0] += 2 * np.pi
     lon_data[lon_data >= 2 * np.pi] -= 2 * np.pi
 
@@ -56,14 +55,13 @@ def direct_transform(*, lon: Quantity, lat: Quantity, stretch_factor: float, lon
     sin_o = - (sin_p * sin_lat + cos_p * cos_lat * np.cos(lon_data))
     tmp = 1 - np.abs(sin_o)
 
-
     lon_trans = np.zeros(lon_data.shape) * np.nan
     lat_trans = np.zeros(lat_data.shape) * np.nan
 
     lon_trans[tmp < 1e-7] = 0.
     lat_trans[tmp < 1e-7] = _sign(np.pi / 2, sin_o[tmp < 1e-7])
 
-    lon_trans[tmp >= 1e-7] = lon_p + np.arctan2(-np.cos(lat_t[tmp >= 1e-7]) * np.sin(lon[tmp >= 1e-7]), -np.sin(lat_t[tmp >= 1e-7])*np.cos(lat_p) + np.cos(lat_t[tmp >= 1e-7]) * np.sin(lat_p) * np.cos(lon[tmp >= 1e-7]))
+    lon_trans[tmp >= 1e-7] = lon_p + np.arctan2(-np.cos(lat_t[tmp >= 1e-7]) * np.sin(lon_data[tmp >= 1e-7]), -np.sin(lat_t[tmp >= 1e-7])*np.cos(lat_p) + np.cos(lat_t[tmp >= 1e-7]) * np.sin(lat_p) * np.cos(lon_data[tmp >= 1e-7]))
     lat_trans[tmp >= 1e-7] = np.arcsin(sin_o[tmp >= 1e-7])
 
     lon_trans[lon_trans < 0] += 2 * np.pi


### PR DESCRIPTION
## Purpose

Added function that allows for Schmidt grid transformation - provided a stretch factor and target longitude and latitude.
Tile 6 (S pole) is shrunk by stretch_factor (all other tiles are stretched to compensate), and then tile 6 is shifted so it is centered on target longitude and latitude.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
