### PR TITLE
Add test that init is decomposition invariant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,18 +19,20 @@ commands:
               python3-pip \
       - restore_cache:
           keys:
-            - v3-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+            - v1-venv-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
       - run:
           name: setup python environment
           command: |
+            python3 -m venv venv
+            . venv/bin/activate
             pip3 install --upgrade setuptools wheel
             pip3 install -r requirements_dev.txt -c constraints.txt
             python3 -m gt4py.gt_src_manager install
       - save_cache:
-          key: v3-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+          key: v1-venv-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
           paths:
-            - /home/circleci/.cache/pip
-            - /opt/circleci/.pyenv/versions
+            - venv
+            - /root/.cache/pip
 
 jobs:
 
@@ -176,10 +178,14 @@ jobs:
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     steps:
-      - checkout
-      - run:
-          name: Update Submodules
-          command: git submodule update --init
+      - run: |
+          sudo apt-get update && sudo apt-get install -y make \
+            software-properties-common \
+            libopenmpi3 \
+            libopenmpi-dev \
+            libboost-all-dev \
+            python3 \
+            python3-pip \
       - gcp-cli/install:
         version: 323.0.0
       - run:
@@ -189,14 +195,32 @@ jobs:
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
             gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
             gcloud auth configure-docker
+      - checkout
+      - run:
+          name: Update Submodules
+          command: git submodule update --init
       - run:
           name: save gt4py_version.txt
           command: git submodule status external/gt4py | awk '{print $1;}' > gt4py_version.txt
       - restore_cache:
           keys:
             - v3-gt_cache_54ranks-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+      - restore_cache:
+          keys:
             - v2-savepoints-c12_54ranks_standard-{{ checksum "Makefile.data_download" }}
-      - setup_environment_mpi
+      - restore_cache:
+          keys:
+            - v4-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+      - run:
+          name: set up environment
+          command: |
+            pip3 install --upgrade setuptools wheel
+            pip3 install -r requirements_dev.txt -c constraints.txt
+            python3 -m gt4py.gt_src_manager install
+      - save_cache:
+          key: v4-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+          paths:
+            - /home/circleci/.cache/pip
       - run:
           name: run tests
           command: |
@@ -296,6 +320,7 @@ jobs:
       - run:
           name: run tests
           command: |
+            . venv/bin/activate
             pytest tests/main
 
   test_mpi_54rank:
@@ -311,6 +336,7 @@ jobs:
       - run:
           name: run tests
           command: |
+            . venv/bin/activate
             mpirun -n 54 --oversubscribe python3 -m mpi4py -m pytest tests/mpi_54rank
 
   test_notebooks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,7 @@ jobs:
   test_mpi_54rank:
     docker:
       - image: cimg/python:3.8
+    resource_class: large
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,35 @@ orbs:
   gcp-cli: circleci/gcp-cli@2.4.1
   gcp-gcr: circleci/gcp-gcr@0.15.0
 
+commands:
+  setup_environment_mpi:
+    description: "Setup environment with MPI"
+    steps:
+      - run:
+          name: setup mpi
+          command: |
+            sudo apt-get update && sudo apt-get install -y make \
+              software-properties-common \
+              libopenmpi3 \
+              libopenmpi-dev \
+              libboost-all-dev \
+              python3 \
+              python3-pip \
+      - restore_cache:
+          keys:
+            - v3-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+      - run:
+          name: setup python environment
+          command: |
+            pip3 install --upgrade setuptools wheel
+            pip3 install -r requirements_dev.txt -c constraints.txt
+            python3 -m gt4py.gt_src_manager install
+      - save_cache:
+          key: v3-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+          paths:
+            - /home/circleci/.cache/pip
+            - /opt/circleci/.pyenv/versions
+
 jobs:
 
   lint:
@@ -147,14 +176,10 @@ jobs:
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     steps:
-      - run: |
-          sudo apt-get update && sudo apt-get install -y make \
-            software-properties-common \
-            libopenmpi3 \
-            libopenmpi-dev \
-            libboost-all-dev \
-            python3 \
-            python3-pip \
+      - checkout
+      - run:
+          name: Update Submodules
+          command: git submodule update --init
       - gcp-cli/install:
         version: 323.0.0
       - run:
@@ -164,10 +189,6 @@ jobs:
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
             gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
             gcloud auth configure-docker
-      - checkout
-      - run:
-          name: Update Submodules
-          command: git submodule update --init
       - run:
           name: save gt4py_version.txt
           command: git submodule status external/gt4py | awk '{print $1;}' > gt4py_version.txt
@@ -175,18 +196,7 @@ jobs:
           keys:
             - v3-gt_cache_54ranks-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
             - v2-savepoints-c12_54ranks_standard-{{ checksum "Makefile.data_download" }}
-            - v3-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
-      - run:
-          name: set up environment
-          command: |
-            pip3 install --upgrade setuptools wheel
-            pip3 install -r requirements_dev.txt -c constraints.txt
-            python3 -m gt4py.gt_src_manager install
-      - save_cache:
-          key: v3-pip_cache-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
-          paths:
-            - /home/circleci/.cache/pip
-            - /opt/circleci/.pyenv/versions
+      - setup_environment_mpi
       - run:
           name: run tests
           command: |
@@ -282,32 +292,11 @@ jobs:
       - run:
           name: Install Submodules
           command: git submodule update --init
-      - run:
-          name: install MPI
-          command: |
-              sudo apt-get update
-              sudo apt-get install libopenmpi3 libopenmpi-dev
-      - restore_cache:
-          keys:
-            - v1-main-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
-      - run:
-          name: install packages
-          command: |
-            if [ $(python changed_from_main.py fv3core) != false ]; then
-              pip3 install --upgrade setuptools wheel virtualenv
-              virtualenv venv
-              . venv/bin/activate
-              pip3 install -r requirements_dev.txt -c constraints.txt
-            fi
+      - setup_environment_mpi
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
             pytest tests/main
-      - save_cache:
-          key: v1-main-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
-          paths:
-            - venv
 
   test_mpi_54rank:
     docker:
@@ -318,32 +307,11 @@ jobs:
       - run:
           name: Install Submodules
           command: git submodule update --init
-      - run:
-          name: install MPI
-          command: |
-              sudo apt-get update
-              sudo apt-get install libopenmpi3 libopenmpi-dev
-      - restore_cache:
-          keys:
-            - v1-main-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
-      - run:
-          name: install packages
-          command: |
-            if [ $(python changed_from_main.py fv3core) != false ]; then
-              pip3 install --upgrade setuptools wheel virtualenv
-              virtualenv venv
-              . venv/bin/activate
-              pip3 install -r requirements_dev.txt -c constraints.txt
-            fi
+      - setup_environment_mpi
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
             mpirun -n 54 --oversubscribe python3 -m mpi4py -m pytest tests/mpi_54rank
-      - save_cache:
-          key: v1-main-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
-          paths:
-            - venv
 
   test_notebooks:
     docker:
@@ -363,7 +331,6 @@ jobs:
       - run:
           name: Test tracer advection
           command: jupyter run examples/notebooks/tracer_advection.ipynb
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            mpirun -n 54 --oversubscribe python3 -m mpi4py -m pytest tests/mpi_54rank
+            mpirun -n 54 --oversubscribe --mca btl_vader_single_copy_mechanism none python3 -m mpi4py -m pytest tests/mpi_54rank
 
   test_notebooks:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,42 @@ jobs:
           paths:
             - venv
 
+  test_mpi_54rank:
+    docker:
+      - image: cimg/python:3.8
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Install Submodules
+          command: git submodule update --init
+      - run:
+          name: install MPI
+          command: |
+              sudo apt-get update
+              sudo apt-get install libopenmpi3 libopenmpi-dev
+      - restore_cache:
+          keys:
+            - v1-main-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+      - run:
+          name: install packages
+          command: |
+            if [ $(python changed_from_main.py fv3core) != false ]; then
+              pip3 install --upgrade setuptools wheel virtualenv
+              virtualenv venv
+              . venv/bin/activate
+              pip3 install -r requirements_dev.txt -c constraints.txt
+            fi
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            mpirun -n 54 --oversubscribe python3 -m mpi4py -m pytest tests/mpi_54rank
+      - save_cache:
+          key: v1-main-{{ checksum "requirements_dev.txt" }}-{{ checksum "constraints.txt" }}
+          paths:
+            - venv
+
   test_notebooks:
     docker:
       - image: gcr.io/vcm-ml/pace_notebook_examples
@@ -374,6 +410,10 @@ workflows:
             tags:
               only: /^v.*/
       - test_main:
+          filters:
+            tags:
+              only: /^v.*/
+      - test_mpi_54rank:
           filters:
             tags:
               only: /^v.*/

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ else
 	CONTAINER_FLAGS=
 endif
 NUM_RANKS ?=6
-MPIRUN_ARGS ?=--oversubscribe
+MPIRUN_ARGS ?=--oversubscribe --mca btl_vader_single_copy_mechanism none
 MPIRUN_CALL ?=mpirun -np $(NUM_RANKS) $(MPIRUN_ARGS)
 TEST_ARGS ?=-v
 TEST_TYPE=$(word 3, $(subst _, ,$(EXPERIMENT)))
@@ -127,6 +127,9 @@ physics_savepoint_tests_mpi: build
 
 test_main: build
 	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "pip3 list && cd $(PACE_PATH) && pytest $(TEST_ARGS) $(PACE_PATH)/tests/main"
+
+test_mpi_54rank:
+	mpirun -n 54 $(MPIRUN_ARGS) python3 -m mpi4py -m pytest tests/mpi_54rank
 
 driver_savepoint_tests_mpi: build
 	TARGET=driver $(MAKE) get_test_data

--- a/fv3core/pace/fv3core/initialization/__init__.py
+++ b/fv3core/pace/fv3core/initialization/__init__.py
@@ -1,0 +1,1 @@
+from .baroclinic import init_baroclinic_state

--- a/tests/main/test_grid_init.py
+++ b/tests/main/test_grid_init.py
@@ -1,0 +1,128 @@
+import numpy as np
+import pytest
+
+import pace.util
+from pace.util.grid import MetricTerms
+
+
+def get_cube_comm(layout, rank: int):
+    return pace.util.CubedSphereCommunicator(
+        comm=pace.util.NullComm(rank=rank, total_ranks=6 * layout[0] * layout[1]),
+        partitioner=pace.util.CubedSpherePartitioner(
+            pace.util.TilePartitioner(layout=layout)
+        ),
+    )
+
+
+def get_quantity_factory(layout, nx_tile, ny_tile, nz):
+    nx = nx_tile // layout[0]
+    ny = ny_tile // layout[1]
+    return pace.util.QuantityFactory(
+        sizer=pace.util.SubtileGridSizer(
+            nx=nx, ny=ny, nz=nz, n_halo=3, extra_dim_lengths={}
+        ),
+        numpy=np,
+    )
+
+
+@pytest.mark.parametrize("rank", [0, 1, 4])
+def test_grid_init_not_decomposition_dependent(rank: int):
+    """
+    This is a limited version of the full grid and state init tests in the
+    mpi_54rank test suite. It tests only variables that are not dependent on
+    halo updates for their values in the compute domain.
+    """
+    nx_tile, ny_tile, nz = 48, 48, 5
+    metric_terms_1by1 = MetricTerms(
+        quantity_factory=get_quantity_factory(
+            layout=(1, 1), nx_tile=nx_tile, ny_tile=ny_tile, nz=nz
+        ),
+        communicator=get_cube_comm(rank=0, layout=(1, 1)),
+    )
+    metric_terms_3by3 = MetricTerms(
+        quantity_factory=get_quantity_factory(
+            layout=(3, 3), nx_tile=nx_tile, ny_tile=ny_tile, nz=nz
+        ),
+        communicator=get_cube_comm(rank=rank, layout=(3, 3)),
+    )
+    partitioner = pace.util.TilePartitioner(layout=(3, 3))
+    assert allclose(metric_terms_1by1.grid, metric_terms_3by3.grid, partitioner, rank)
+    assert allclose(metric_terms_1by1.agrid, metric_terms_3by3.agrid, partitioner, rank)
+    assert allclose(metric_terms_1by1.area, metric_terms_3by3.area, partitioner, rank)
+    assert allclose(
+        metric_terms_1by1.area_c, metric_terms_3by3.rarea_c, partitioner, rank
+    )
+    assert allclose(metric_terms_1by1.dx, metric_terms_3by3.dx, partitioner, rank)
+    assert allclose(metric_terms_1by1.dy, metric_terms_3by3.dy, partitioner, rank)
+    assert allclose(metric_terms_1by1.dxa, metric_terms_3by3.dxa, partitioner, rank)
+    assert allclose(metric_terms_1by1.dya, metric_terms_3by3.dya, partitioner, rank)
+    assert allclose(
+        metric_terms_1by1.cos_sg1, metric_terms_3by3.cos_sg1, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.cos_sg2, metric_terms_3by3.cos_sg2, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.cos_sg3, metric_terms_3by3.cos_sg3, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.cos_sg4, metric_terms_3by3.cos_sg4, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.sin_sg1, metric_terms_3by3.sin_sg1, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.sin_sg2, metric_terms_3by3.sin_sg2, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.sin_sg3, metric_terms_3by3.sin_sg3, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.sin_sg4, metric_terms_3by3.sin_sg4, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.rarea_c, metric_terms_3by3.rarea_c, partitioner, rank
+    )
+    assert allclose(metric_terms_1by1.rarea, metric_terms_3by3.rarea, partitioner, rank)
+    assert allclose(metric_terms_1by1.rdx, metric_terms_3by3.rdx, partitioner, rank)
+    assert allclose(metric_terms_1by1.rdy, metric_terms_3by3.rdy, partitioner, rank)
+    assert allclose(metric_terms_1by1.cosa, metric_terms_3by3.cosa, partitioner, rank)
+    assert allclose(metric_terms_1by1.sina, metric_terms_3by3.sina, partitioner, rank)
+    assert allclose(metric_terms_1by1.rsina, metric_terms_3by3.rsina, partitioner, rank)
+    assert allclose(
+        metric_terms_1by1.cosa_u, metric_terms_3by3.cosa_u, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.cosa_v, metric_terms_3by3.cosa_v, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.sina_u, metric_terms_3by3.sina_u, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.sina_v, metric_terms_3by3.sina_v, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.divg_u, metric_terms_3by3.divg_u, partitioner, rank
+    )
+    assert allclose(
+        metric_terms_1by1.divg_v, metric_terms_3by3.divg_u, partitioner, rank
+    )
+
+
+def allclose(
+    q_1by1: pace.util.Quantity,
+    q_3by3: pace.util.Quantity,
+    partitioner: pace.util.TilePartitioner,
+    rank: int,
+):
+    subtile_slice = partitioner.subtile_slice(
+        rank=rank, global_dims=q_1by1.dims, global_extent=q_1by1.extent, overlap=True
+    )
+    v1 = q_1by1.view[subtile_slice]
+    v2 = q_3by3.view[:]
+    assert v1.shape == v2.shape
+    same = (v1 == v2) | np.isnan(v1)
+    all_same = np.all(same)
+    if not all_same:
+        print(np.sum(~same), np.where(~same))
+    return all_same

--- a/tests/main/test_grid_init.py
+++ b/tests/main/test_grid_init.py
@@ -49,9 +49,6 @@ def test_grid_init_not_decomposition_dependent(rank: int):
     assert allclose(metric_terms_1by1.grid, metric_terms_3by3.grid, partitioner, rank)
     assert allclose(metric_terms_1by1.agrid, metric_terms_3by3.agrid, partitioner, rank)
     assert allclose(metric_terms_1by1.area, metric_terms_3by3.area, partitioner, rank)
-    assert allclose(
-        metric_terms_1by1.area_c, metric_terms_3by3.rarea_c, partitioner, rank
-    )
     assert allclose(metric_terms_1by1.dx, metric_terms_3by3.dx, partitioner, rank)
     assert allclose(metric_terms_1by1.dy, metric_terms_3by3.dy, partitioner, rank)
     assert allclose(metric_terms_1by1.dxa, metric_terms_3by3.dxa, partitioner, rank)
@@ -80,33 +77,9 @@ def test_grid_init_not_decomposition_dependent(rank: int):
     assert allclose(
         metric_terms_1by1.sin_sg4, metric_terms_3by3.sin_sg4, partitioner, rank
     )
-    assert allclose(
-        metric_terms_1by1.rarea_c, metric_terms_3by3.rarea_c, partitioner, rank
-    )
     assert allclose(metric_terms_1by1.rarea, metric_terms_3by3.rarea, partitioner, rank)
     assert allclose(metric_terms_1by1.rdx, metric_terms_3by3.rdx, partitioner, rank)
     assert allclose(metric_terms_1by1.rdy, metric_terms_3by3.rdy, partitioner, rank)
-    assert allclose(metric_terms_1by1.cosa, metric_terms_3by3.cosa, partitioner, rank)
-    assert allclose(metric_terms_1by1.sina, metric_terms_3by3.sina, partitioner, rank)
-    assert allclose(metric_terms_1by1.rsina, metric_terms_3by3.rsina, partitioner, rank)
-    assert allclose(
-        metric_terms_1by1.cosa_u, metric_terms_3by3.cosa_u, partitioner, rank
-    )
-    assert allclose(
-        metric_terms_1by1.cosa_v, metric_terms_3by3.cosa_v, partitioner, rank
-    )
-    assert allclose(
-        metric_terms_1by1.sina_u, metric_terms_3by3.sina_u, partitioner, rank
-    )
-    assert allclose(
-        metric_terms_1by1.sina_v, metric_terms_3by3.sina_v, partitioner, rank
-    )
-    assert allclose(
-        metric_terms_1by1.divg_u, metric_terms_3by3.divg_u, partitioner, rank
-    )
-    assert allclose(
-        metric_terms_1by1.divg_v, metric_terms_3by3.divg_u, partitioner, rank
-    )
 
 
 def allclose(

--- a/tests/mpi_54rank/test_grid_init.py
+++ b/tests/mpi_54rank/test_grid_init.py
@@ -1,0 +1,232 @@
+from typing import Dict
+
+import numpy as np
+
+import pace.fv3core
+import pace.util
+from pace.fv3core.initialization import init_baroclinic_state
+from pace.util.grid import MetricTerms
+from pace.util.mpi import MPIComm
+from pace.util.quantity import Quantity
+
+
+def get_cube_comm(layout, comm: MPIComm):
+    return pace.util.CubedSphereCommunicator(
+        comm=comm,
+        partitioner=pace.util.CubedSpherePartitioner(
+            pace.util.TilePartitioner(layout=layout)
+        ),
+    )
+
+
+def get_quantity_factory(layout, nx_tile, ny_tile, nz):
+    nx = nx_tile // layout[0]
+    ny = ny_tile // layout[1]
+    return pace.util.QuantityFactory(
+        sizer=pace.util.SubtileGridSizer(
+            nx=nx, ny=ny, nz=nz, n_halo=3, extra_dim_lengths={}
+        ),
+        numpy=np,
+    )
+
+
+def metric_terms_to_quantity_dict(metric_terms: MetricTerms) -> Dict[str, Quantity]:
+    return {
+        "grid": metric_terms.grid,
+        "agrid": metric_terms.agrid,
+        "area": metric_terms.area,
+        "area_c": metric_terms.area_c,
+        "dx": metric_terms.dx,
+        "dy": metric_terms.dy,
+        "dxa": metric_terms.dxa,
+        "dya": metric_terms.dya,
+        "dxc": metric_terms.dxc,
+        "dyc": metric_terms.dyc,
+        "ec1": metric_terms.ec1,
+        "ec2": metric_terms.ec2,
+        "ew1": metric_terms.ew1,
+        "ew2": metric_terms.ew2,
+        "cos_sg1": metric_terms.cos_sg1,
+        "cos_sg2": metric_terms.cos_sg2,
+        "cos_sg3": metric_terms.cos_sg3,
+        "cos_sg4": metric_terms.cos_sg4,
+        "cos_sg5": metric_terms.cos_sg5,
+        "cos_sg6": metric_terms.cos_sg6,
+        "cos_sg7": metric_terms.cos_sg7,
+        "cos_sg8": metric_terms.cos_sg8,
+        "cos_sg9": metric_terms.cos_sg9,
+        "sin_sg1": metric_terms.sin_sg1,
+        "sin_sg2": metric_terms.sin_sg2,
+        "sin_sg3": metric_terms.sin_sg3,
+        "sin_sg4": metric_terms.sin_sg4,
+        "sin_sg5": metric_terms.sin_sg5,
+        "sin_sg6": metric_terms.sin_sg6,
+        "sin_sg7": metric_terms.sin_sg7,
+        "sin_sg8": metric_terms.sin_sg8,
+        "sin_sg9": metric_terms.sin_sg9,
+        "rarea_c": metric_terms.rarea_c,
+        "rarea": metric_terms.rarea,
+        "rdx": metric_terms.rdx,
+        "rdy": metric_terms.rdy,
+        "rdxa": metric_terms.rdxa,
+        "rdya": metric_terms.rdya,
+        "rdxc": metric_terms.rdxc,
+        "rdyc": metric_terms.rdyc,
+        "cosa": metric_terms.cosa,
+        "sina": metric_terms.sina,
+        "rsina": metric_terms.rsina,
+        "rsin2": metric_terms.rsin2,
+        "l2c_v": metric_terms.l2c_v,
+        "l2c_u": metric_terms.l2c_u,
+        "es1": metric_terms.es1,
+        "es2": metric_terms.es2,
+        "ee1": metric_terms.ee1,
+        "ee2": metric_terms.ee2,
+        "rsin_u": metric_terms.rsin_u,
+        "rsin_v": metric_terms.rsin_v,
+        "cosa_u": metric_terms.cosa_u,
+        "cosa_v": metric_terms.cosa_v,
+        "cosa_s": metric_terms.cosa_s,
+        "sina_u": metric_terms.sina_u,
+        "sina_v": metric_terms.sina_v,
+        "divg_u": metric_terms.divg_u,
+        "divg_v": metric_terms.divg_v,
+        "del6_u": metric_terms.del6_u,
+        "del6_v": metric_terms.del6_v,
+        "vlon": metric_terms.vlon,
+        "vlat": metric_terms.vlat,
+        "z11": metric_terms.z11,
+        "z12": metric_terms.z12,
+        "z21": metric_terms.z21,
+        "z22": metric_terms.z22,
+        "a11": metric_terms.a11,
+        "a12": metric_terms.a12,
+        "a21": metric_terms.a21,
+        "a22": metric_terms.a22,
+        "edge_w": metric_terms.edge_w,
+        "edge_e": metric_terms.edge_e,
+        "edge_s": metric_terms.edge_s,
+        "edge_n": metric_terms.edge_n,
+        "edge_vect_w": metric_terms.edge_vect_w,
+        "edge_vect_w_2d": metric_terms.edge_vect_w_2d,
+        "edge_vect_e": metric_terms.edge_vect_e,
+        "edge_vect_e_2d": metric_terms.edge_vect_e_2d,
+        "edge_vect_s": metric_terms.edge_vect_s,
+        "edge_vect_n": metric_terms.edge_vect_n,
+    }
+
+
+def dycore_state_to_quantity_dict(
+    dycore_state: pace.fv3core.DycoreState,
+) -> Dict[str, Quantity]:
+    return {
+        "u": dycore_state.u,
+        "v": dycore_state.u,
+        "delp": dycore_state.delp,
+        "delz": dycore_state.delz,
+        "pt": dycore_state.pt,
+        "ps": dycore_state.ps,
+        "peln": dycore_state.peln,
+        "pk": dycore_state.pk,
+        "pkz": dycore_state.pkz,
+        "pe": dycore_state.pe,
+        "phis": dycore_state.phis,
+        "w": dycore_state.w,
+        "qvapor": dycore_state.qvapor,
+    }
+
+
+def gather_all(
+    quantity_dict: Dict[str, Quantity], tile_comm: pace.util.TileCommunicator
+) -> Dict[str, Quantity]:
+    gathered = {}
+    for name, quantity in quantity_dict.items():
+        gathered[name] = tile_comm.gather(quantity)
+    return gathered
+
+
+def test_grid_init_not_decomposition_dependent():
+    nx_tile, ny_tile, nz = 48, 48, 5
+    # use all ranks for 3x3 decomposition of single tile
+    # we can use TileCommunicator for halo updates
+    comm_3by3 = MPIComm()
+    global_rank = comm_3by3.Get_rank()
+    cube_comm = get_cube_comm(layout=(3, 3), comm=comm_3by3)
+    metric_terms_3by3 = MetricTerms(
+        quantity_factory=get_quantity_factory(
+            layout=(3, 3), nx_tile=nx_tile, ny_tile=ny_tile, nz=nz
+        ),
+        communicator=cube_comm,
+    )
+    computed_3by3 = metric_terms_to_quantity_dict(metric_terms_3by3)
+    gathered_3by3 = gather_all(computed_3by3, cube_comm.tile)
+    # only need 6 ranks for 1x1 decomposition, should be root rank of each tile
+    # so we can easily gather on each tile
+    compute_1by1 = cube_comm.tile.rank == 0
+    comm_1by1 = comm_3by3.Split(color=int(compute_1by1), key=global_rank)
+    if compute_1by1:
+        metric_terms_1by1 = MetricTerms(
+            quantity_factory=get_quantity_factory(
+                layout=(1, 1), nx_tile=nx_tile, ny_tile=ny_tile, nz=nz
+            ),
+            communicator=get_cube_comm(layout=(1, 1), comm=comm_1by1),
+        )
+        computed_1by1 = metric_terms_to_quantity_dict(metric_terms_1by1)
+        for name in computed_1by1:
+            assert allclose(computed_1by1[name], gathered_3by3[name], name)
+
+
+def test_baroclinic_init_not_decomposition_dependent():
+    nx_tile, ny_tile, nz = 24, 24, 79
+    # use all ranks for 3x3 decomposition of single tile
+    # we can use TileCommunicator for halo updates
+    comm_3by3 = MPIComm()
+    global_rank = comm_3by3.Get_rank()
+    cube_comm_3by3 = get_cube_comm(layout=(3, 3), comm=comm_3by3)
+    metric_terms_3by3 = MetricTerms(
+        quantity_factory=get_quantity_factory(
+            layout=(3, 3), nx_tile=nx_tile, ny_tile=ny_tile, nz=nz
+        ),
+        communicator=cube_comm_3by3,
+    )
+    state_3by3 = init_baroclinic_state(
+        metric_terms=metric_terms_3by3,
+        adiabatic=False,
+        hydrostatic=False,
+        moist_phys=True,
+        comm=cube_comm_3by3,
+    )
+    computed_3by3 = dycore_state_to_quantity_dict(state_3by3)
+    gathered_3by3 = gather_all(computed_3by3, cube_comm_3by3.tile)
+    # only need 6 ranks for 1x1 decomposition, should be root rank of each tile
+    # so we can easily gather on each tile
+    compute_1by1 = cube_comm_3by3.tile.rank == 0
+    comm_1by1 = comm_3by3.Split(color=int(compute_1by1), key=global_rank)
+    if compute_1by1:
+        cube_comm_1by1 = get_cube_comm(layout=(1, 1), comm=comm_1by1)
+        metric_terms_1by1 = MetricTerms(
+            quantity_factory=get_quantity_factory(
+                layout=(1, 1), nx_tile=nx_tile, ny_tile=ny_tile, nz=nz
+            ),
+            communicator=cube_comm_1by1,
+        )
+        state_1by1 = init_baroclinic_state(
+            metric_terms=metric_terms_1by1,
+            adiabatic=False,
+            hydrostatic=False,
+            moist_phys=True,
+            comm=cube_comm_1by1,
+        )
+        computed_1by1 = dycore_state_to_quantity_dict(state_1by1)
+        for name in computed_1by1:
+            assert allclose(computed_1by1[name], gathered_3by3[name], name)
+
+
+def allclose(q_1by1: pace.util.Quantity, q_3by3: pace.util.Quantity, name: str):
+    print("1by1", q_1by1.metadata, "3by3", q_3by3.metadata)
+    assert q_1by1.view[:].shape == q_3by3.view[:].shape, name
+    same = (q_1by1.view[:] == q_3by3.view[:]) | np.isnan(q_1by1.view[:])
+    all_same = np.all(same)
+    if not all_same:
+        print(np.sum(~same), np.where(~same))
+    return all_same

--- a/util/pace/util/grid/generation.py
+++ b/util/pace/util/grid/generation.py
@@ -1322,8 +1322,8 @@ class MetricTerms:
         return util.Quantity(
             data=1.0 / self.dya.data,
             dims=self.dya.dims,
-            origin=self.dy.origin,
-            extent=self.dy.extent,
+            origin=self.dya.origin,
+            extent=self.dya.extent,
             units="m^-1",
             gt4py_backend=self.dya.gt4py_backend,
         )

--- a/util/pace/util/grid/generation.py
+++ b/util/pace/util/grid/generation.py
@@ -1322,6 +1322,8 @@ class MetricTerms:
         return util.Quantity(
             data=1.0 / self.dya.data,
             dims=self.dya.dims,
+            origin=self.dy.origin,
+            extent=self.dy.extent,
             units="m^-1",
             gt4py_backend=self.dya.gt4py_backend,
         )

--- a/util/pace/util/grid/generation.py
+++ b/util/pace/util/grid/generation.py
@@ -95,7 +95,6 @@ class MetricTerms:
                 self.LON_OR_LAT_DIM: 2,
                 self.TILE_DIM: 6,
                 self.CARTESIAN_DIM: 3,
-                util.X_DIM: 1,
             }
         )
         self._grid_indexing = GridIndexing.from_sizer_and_communicator(
@@ -411,7 +410,7 @@ class MetricTerms:
     def ec1(self) -> util.Quantity:
         """
         cartesian components of the local unit vetcor
-        in the x-direation at the cell centers
+        in the x-direction at the cell centers
         3d array whose last dimension is length 3 and indicates cartesian x/y/z value
         """
         if self._ec1 is None:
@@ -1249,6 +1248,8 @@ class MetricTerms:
         return util.Quantity(
             data=1.0 / self.area.data,
             dims=self.area.dims,
+            origin=self.area.origin,
+            extent=self.area.extent,
             units="m^-2",
             gt4py_backend=self.area.gt4py_backend,
         )
@@ -1261,6 +1262,8 @@ class MetricTerms:
         return util.Quantity(
             data=1.0 / self.area_c.data,
             dims=self.area_c.dims,
+            origin=self.area_c.origin,
+            extent=self.area_c.extent,
             units="m^-2",
             gt4py_backend=self.area_c.gt4py_backend,
         )
@@ -1274,6 +1277,8 @@ class MetricTerms:
         return util.Quantity(
             data=1.0 / self.dx.data,
             dims=self.dx.dims,
+            origin=self.dx.origin,
+            extent=self.dx.extent,
             units="m^-1",
             gt4py_backend=self.dx.gt4py_backend,
         )
@@ -1287,6 +1292,8 @@ class MetricTerms:
         return util.Quantity(
             data=1.0 / self.dy.data,
             dims=self.dy.dims,
+            origin=self.dy.origin,
+            extent=self.dy.extent,
             units="m^-1",
             gt4py_backend=self.dy.gt4py_backend,
         )
@@ -1300,6 +1307,8 @@ class MetricTerms:
         return util.Quantity(
             data=1.0 / self.dxa.data,
             dims=self.dxa.dims,
+            origin=self.dxa.origin,
+            extent=self.dxa.extent,
             units="m^-1",
             gt4py_backend=self.dxa.gt4py_backend,
         )
@@ -1326,6 +1335,8 @@ class MetricTerms:
         return util.Quantity(
             data=1.0 / self.dxc.data,
             dims=self.dxc.dims,
+            origin=self.dxc.origin,
+            extent=self.dxc.extent,
             units="m^-1",
             gt4py_backend=self.dxc.gt4py_backend,
         )
@@ -1339,6 +1350,8 @@ class MetricTerms:
         return util.Quantity(
             data=1.0 / self.dyc.data,
             dims=self.dyc.dims,
+            origin=self.dyc.origin,
+            extent=self.dyc.extent,
             units="m^-1",
             gt4py_backend=self.dyc.gt4py_backend,
         )


### PR DESCRIPTION
## Purpose

This PR adds unit tests to ensure that the compute domain data of the grid and baroclinic initial state are not dependent on domain decomposition.

These tests are run on CircleCI under a new plan.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
