### PR TITLE
DaCe Orchestration: fix parsing, de-inline grid data scalars & memory leak

### DIFF
--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -265,13 +265,13 @@ class Driver:
                 obj=self,
                 config=self.config.stencil_config.dace_config,
                 method_to_orchestrate="_critical_path_step_all",
-                dace_constant_args=["timer"],
+                dace_compiletime_args=["timer"],
             )
             orchestrate(
                 obj=self,
                 config=self.config.stencil_config.dace_config,
                 method_to_orchestrate="_step_dynamics",
-                dace_constant_args=["state", "timer"],
+                dace_compiletime_args=["state", "timer"],
             )
             orchestrate(
                 obj=self,

--- a/dsl/pace/dsl/dace/build.py
+++ b/dsl/pace/dsl/dace/build.py
@@ -170,7 +170,9 @@ def get_sdfg_path(
             )
         # Check resolution per tile
         build_resolution = ast.literal_eval(build_info_file.readline())
-        if config.tile_resolution != build_resolution:
+        if (config.tile_resolution[0] / config.layout[0]) != (
+            build_resolution[0] / build_layout[0]
+        ):
             raise RuntimeError(
                 f"SDFG build for resolution {build_resolution}, "
                 f"cannot be run with current resolution {config.tile_resolution}"

--- a/dsl/pace/dsl/dace/dace_config.py
+++ b/dsl/pace/dsl/dace/dace_config.py
@@ -10,7 +10,7 @@ from pace.util.communicator import CubedSphereCommunicator
 # TODO (floriand): Temporary deactivate the distributed compiled
 # until we deal with the Grid data inlining during orchestration
 # See github issue #301
-DEACTIVATE_DISTRIBUTED_DACE_COMPILE = True
+DEACTIVATE_DISTRIBUTED_DACE_COMPILE = False
 
 
 class DaCeOrchestration(enum.Enum):

--- a/dsl/pace/dsl/dace/dace_config.py
+++ b/dsl/pace/dsl/dace/dace_config.py
@@ -7,9 +7,9 @@ from pace.dsl.gt4py_utils import is_gpu_backend
 from pace.util.communicator import CubedSphereCommunicator
 
 
-# TODO (floriand): Temporary deactivate the distributed compiled
-# until we deal with the Grid data inlining during orchestration
-# See github issue #301
+# This can be turned on to revert compilation for orchestration
+# in a rank-compile-itself more, instead of the distributed top-tile
+# mechanism.
 DEACTIVATE_DISTRIBUTED_DACE_COMPILE = False
 
 

--- a/dsl/pace/dsl/dace/dace_config.py
+++ b/dsl/pace/dsl/dace/dace_config.py
@@ -10,7 +10,7 @@ from pace.util.communicator import CubedSphereCommunicator
 # TODO (floriand): Temporary deactivate the distributed compiled
 # until we deal with the Grid data inlining during orchestration
 # See github issue #301
-DEACTIVATE_DISTRIBUTED_DACE_COMPILE = False
+DEACTIVATE_DISTRIBUTED_DACE_COMPILE = True
 
 
 class DaCeOrchestration(enum.Enum):

--- a/dsl/pace/dsl/dace/orchestration.py
+++ b/dsl/pace/dsl/dace/orchestration.py
@@ -435,8 +435,8 @@ def orchestrate(
         obj: object which methods is to be orchestrated
         config: DaceConfig carrying model configuration
         method_to_orchestrate: string representing the name of the method
-        dace_compiletime_args: list of names of arguments to be flagged has dace.constant
-                            for orchestration to behave
+        dace_compiletime_args: list of names of arguments to be flagged has
+                               dace.compiletime for orchestration to behave
     """
 
     if config.is_dace_orchestrated():
@@ -517,8 +517,8 @@ def orchestrate_function(
 
     Args:
         config: DaceConfig carrying model configuration
-        dace_compiletime_args: list of names of arguments to be flagged has dace.constant
-                            for orchestration to behave
+        dace_compiletime_args: list of names of arguments to be flagged has
+                               dace.compiletime for orchestration to behave
     """
 
     def _decorator(func: Callable[..., Any]):

--- a/dsl/pace/dsl/dace/orchestration.py
+++ b/dsl/pace/dsl/dace/orchestration.py
@@ -425,7 +425,7 @@ def orchestrate(
     obj: object,
     config: DaceConfig,
     method_to_orchestrate: str = "__call__",
-    dace_constant_args: List[str] = [],
+    dace_compiletime_args: List[str] = [],
 ):
     """
     Orchestrate a method of an object with DaCe.
@@ -435,7 +435,7 @@ def orchestrate(
         obj: object which methods is to be orchestrated
         config: DaceConfig carrying model configuration
         method_to_orchestrate: string representing the name of the method
-        dace_constant_args: list of names of arguments to be flagged has dace.constant
+        dace_compiletime_args: list of names of arguments to be flagged has dace.constant
                             for orchestration to behave
     """
 
@@ -444,7 +444,7 @@ def orchestrate(
             func = type.__getattribute__(type(obj), method_to_orchestrate)
 
             # Flag argument as dace.constant
-            for argument in dace_constant_args:
+            for argument in dace_compiletime_args:
                 func.__annotations__[argument] = DaceCompiletime
 
             # Build DaCe orchestrated wrapper
@@ -509,7 +509,7 @@ def orchestrate(
 
 def orchestrate_function(
     config: DaceConfig = None,
-    dace_constant_args: List[str] = [],
+    dace_compiletime_args: List[str] = [],
 ) -> Union[Callable[..., Any], _LazyComputepathFunction]:
     """
     Decorator orchestrating a method of an object with DaCe.
@@ -517,13 +517,13 @@ def orchestrate_function(
 
     Args:
         config: DaceConfig carrying model configuration
-        dace_constant_args: list of names of arguments to be flagged has dace.constant
+        dace_compiletime_args: list of names of arguments to be flagged has dace.constant
                             for orchestration to behave
     """
 
     def _decorator(func: Callable[..., Any]):
         def _wrapper(*args, **kwargs):
-            for argument in dace_constant_args:
+            for argument in dace_compiletime_args:
                 func.__annotations__[argument] = DaceCompiletime
             return _LazyComputepathFunction(func, config)
 

--- a/dsl/pace/dsl/dace/orchestration.py
+++ b/dsl/pace/dsl/dace/orchestration.py
@@ -422,10 +422,11 @@ class _LazyComputepathMethod:
 
 
 def orchestrate(
+    *,
     obj: object,
     config: DaceConfig,
     method_to_orchestrate: str = "__call__",
-    dace_compiletime_args: List[str] = [],
+    dace_compiletime_args: List[str] = None,
 ):
     """
     Orchestrate a method of an object with DaCe.
@@ -438,6 +439,8 @@ def orchestrate(
         dace_compiletime_args: list of names of arguments to be flagged has
                                dace.compiletime for orchestration to behave
     """
+    if dace_compiletime_args is None:
+        dace_compiletime_args = []
 
     if config.is_dace_orchestrated():
         if hasattr(obj, method_to_orchestrate):
@@ -509,7 +512,7 @@ def orchestrate(
 
 def orchestrate_function(
     config: DaceConfig = None,
-    dace_compiletime_args: List[str] = [],
+    dace_compiletime_args: List[str] = None,
 ) -> Union[Callable[..., Any], _LazyComputepathFunction]:
     """
     Decorator orchestrating a method of an object with DaCe.
@@ -520,6 +523,9 @@ def orchestrate_function(
         dace_compiletime_args: list of names of arguments to be flagged has
                                dace.compiletime for orchestration to behave
     """
+
+    if dace_compiletime_args is None:
+        dace_compiletime_args = []
 
     def _decorator(func: Callable[..., Any]):
         def _wrapper(*args, **kwargs):

--- a/fv3core/examples/standalone/runfile/acoustics.py
+++ b/fv3core/examples/standalone/runfile/acoustics.py
@@ -180,6 +180,7 @@ def driver(
             dycore_config.acoustic_dynamics,
             input_data["pfull"],
             input_data["phis"],
+            input_data["wsd"],
             state,
         )
 

--- a/fv3core/pace/fv3core/stencils/c_sw.py
+++ b/fv3core/pace/fv3core/stencils/c_sw.py
@@ -486,7 +486,7 @@ class CGridShallowWaterDynamics:
         grid_type: int,
         nord: int,
     ):
-        orchestrate(self, config=stencil_factory.config.dace_config)
+        orchestrate(obj=self, config=stencil_factory.config.dace_config)
         grid_indexing = stencil_factory.grid_indexing
         self.grid_data = grid_data
         self._dord4 = True

--- a/fv3core/pace/fv3core/stencils/d2a2c_vect.py
+++ b/fv3core/pace/fv3core/stencils/d2a2c_vect.py
@@ -385,7 +385,7 @@ class DGrid2AGrid2CGridVectors:
         grid_type: int,
         dord4: bool,
     ):
-        orchestrate(self, config=stencil_factory.config.dace_config)
+        orchestrate(obj=self, config=stencil_factory.config.dace_config)
 
         grid_indexing = stencil_factory.grid_indexing
         self._cosa_s = grid_data.cosa_s

--- a/fv3core/pace/fv3core/stencils/del2cubed.py
+++ b/fv3core/pace/fv3core/stencils/del2cubed.py
@@ -91,7 +91,7 @@ class HyperdiffusionDamping:
         Args:
             grid: fv3core grid object
         """
-        orchestrate(self, stencil_factory.config.dace_config)
+        orchestrate(obj=self, config=stencil_factory.config.dace_config)
         grid_indexing = stencil_factory.grid_indexing
         self._del6_u = damping_coefficients.del6_u
         self._del6_v = damping_coefficients.del6_v

--- a/fv3core/pace/fv3core/stencils/divergence_damping.py
+++ b/fv3core/pace/fv3core/stencils/divergence_damping.py
@@ -269,7 +269,7 @@ def smagorinksy_diffusion_approx(delpc: FloatField, vort: FloatField, absdt: flo
     # some kind of u and v, and is vort (as output) some kind of kinetic energy?
     # what does this have to do with diffusion?
     with computation(PARALLEL), interval(...):
-        vort = absdt * (delpc**2.0 + vort**2.0) ** 0.5
+        vort = absdt * (delpc ** 2.0 + vort ** 2.0) ** 0.5
 
 
 class DivergenceDamping:

--- a/fv3core/pace/fv3core/stencils/divergence_damping.py
+++ b/fv3core/pace/fv3core/stencils/divergence_damping.py
@@ -269,7 +269,7 @@ def smagorinksy_diffusion_approx(delpc: FloatField, vort: FloatField, absdt: flo
     # some kind of u and v, and is vort (as output) some kind of kinetic energy?
     # what does this have to do with diffusion?
     with computation(PARALLEL), interval(...):
-        vort = absdt * (delpc ** 2.0 + vort ** 2.0) ** 0.5
+        vort = absdt * (delpc**2.0 + vort**2.0) ** 0.5
 
 
 class DivergenceDamping:
@@ -640,8 +640,8 @@ class DivergenceDamping:
                 abs(dt),
             )
 
-        da_min = self._get_da_min()
-        da_min_c = self._get_da_min_c()
+        da_min: float = self._get_da_min()
+        da_min_c: float = self._get_da_min_c()
         if self._stretched_grid:
             dd8 = da_min * self._d4_bg ** (self._nonzero_nord + 1)
         else:

--- a/fv3core/pace/fv3core/stencils/divergence_damping.py
+++ b/fv3core/pace/fv3core/stencils/divergence_damping.py
@@ -301,8 +301,7 @@ class DivergenceDamping:
         # TODO: make dddmp a compile-time external, instead of runtime scalar
         self._dddmp = dddmp
         # TODO: make da_min_c a compile-time external, instead of runtime scalar
-        self._da_min_c = damping_coefficients.da_min_c
-        self._da_min = damping_coefficients.da_min
+        self._damping_coefficients = damping_coefficients
         self._stretched_grid = stretched_grid
         self._d4_bg = d4_bg
         self._grid_type = grid_type
@@ -499,11 +498,11 @@ class DivergenceDamping:
 
     @dace_inhibitor
     def _get_da_min_c(self) -> float:
-        return self._da_min_c
+        return self._damping_coefficients.da_min_c
 
     @dace_inhibitor
     def _get_da_min(self) -> float:
-        return self._da_min
+        return self._damping_coefficients.da_min
 
     def __call__(
         self,
@@ -596,12 +595,13 @@ class DivergenceDamping:
             )
             """
 
+            da_min_c: float = self._get_da_min_c()
             self._damping(
                 delpc,
                 v_contra_dxc,
                 ke,
                 self._d2_bg_column,
-                self._da_min_c,
+                da_min_c,
                 self._dddmp,
                 dt,
             )
@@ -641,7 +641,6 @@ class DivergenceDamping:
             )
 
         da_min: float = self._get_da_min()
-        da_min_c: float = self._get_da_min_c()
         if self._stretched_grid:
             dd8 = da_min * self._d4_bg ** (self._nonzero_nord + 1)
         else:

--- a/fv3core/pace/fv3core/stencils/divergence_damping.py
+++ b/fv3core/pace/fv3core/stencils/divergence_damping.py
@@ -11,7 +11,7 @@ from gt4py.gtscript import (
 import pace.dsl.gt4py_utils as utils
 import pace.fv3core.stencils.basic_operations as basic
 import pace.stencils.corners as corners
-from pace.dsl.dace.orchestration import orchestrate
+from pace.dsl.dace.orchestration import dace_inhibitor, orchestrate
 from pace.dsl.stencil import StencilFactory, get_stencils_with_varied_bounds
 from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
 from pace.fv3core.stencils.a2b_ord4 import AGrid2BGridFourthOrder
@@ -302,6 +302,9 @@ class DivergenceDamping:
         self._dddmp = dddmp
         # TODO: make da_min_c a compile-time external, instead of runtime scalar
         self._da_min_c = damping_coefficients.da_min_c
+        self._da_min = damping_coefficients.da_min
+        self._stretched_grid = stretched_grid
+        self._d4_bg = d4_bg
         self._grid_type = grid_type
         self._nord_column = nord_col
         self._d2_bg_column = d2_bg
@@ -329,12 +332,7 @@ class DivergenceDamping:
                 nonzero_nord_k = k
                 self._nonzero_nord = int(self._nord_column[k])
                 break
-        if stretched_grid:
-            self._dd8 = damping_coefficients.da_min * d4_bg ** (self._nonzero_nord + 1)
-        else:
-            self._dd8 = (damping_coefficients.da_min_c * d4_bg) ** (
-                self._nonzero_nord + 1
-            )
+
         kstart = nonzero_nord_k
         nk = self.grid_indexing.domain[2] - kstart
         self._do_zero_order = nonzero_nord_k > 0
@@ -475,6 +473,38 @@ class DivergenceDamping:
             compute_halos=(0, 0),
         )
 
+    # We need to use a getter for da_min & da_min_c in order to go around a DaCe inline
+    # behavior. As part of the automatic optimization process, DaCe tries to inline
+    # as many scalars as possible.
+    # The grid is _not_ passed as an input to the top level function we orchestrate,
+    # so its scalar values will be inlined.
+
+    # 'alas, our distributed compilation system works by compiling a 3,3 layout
+    # top tile, then using those 9 caches on every layout upward.
+    # This setup leads to the values of da_min/da_min_c from the 3,3 layout
+    # to be inlined in the generated code. Those variables are used in runtime
+    # calculation (kinetic energy, etc.) which obviously leads to misbehaving numerics
+    # and errors when the 3,3 layout values are used on larger layouts
+
+    # The solution we implement here is making use of the fact that callbacks
+    # are never inlined in dace optimization. the current workaround uses the
+    # following functions.
+
+    # An alternative would be to pass the Grid or the DampingCoefficients to DaCe,
+    # clearly flagging it has a dynamic piece of memory (which would
+    # cancel any inlining) but the feature to do that (dace.struct)
+    # is currently in disarray.
+    # N.B.: another solution is to pass da_min and da_min_c as input, put it seems
+    # odd and adds a lot of boilerplate throughout the model code.
+
+    @dace_inhibitor
+    def _get_da_min_c(self) -> float:
+        return self._da_min_c
+
+    @dace_inhibitor
+    def _get_da_min(self) -> float:
+        return self._da_min
+
     def __call__(
         self,
         u: FloatField,
@@ -609,13 +639,21 @@ class DivergenceDamping:
                 v_contra_dxc,
                 abs(dt),
             )
+
+        da_min = self._get_da_min()
+        da_min_c = self._get_da_min_c()
+        if self._stretched_grid:
+            dd8 = da_min * self._d4_bg ** (self._nonzero_nord + 1)
+        else:
+            dd8 = (da_min_c * self._d4_bg) ** (self._nonzero_nord + 1)
+
         self._damping_nord_highorder_stencil(
             v_contra_dxc,
             ke,
             delpc,
             divg_d,
             self._d2_bg_column,
-            self._da_min_c,
+            da_min_c,
             self._dddmp,
-            self._dd8,
+            dd8,
         )

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -569,11 +569,13 @@ class AcousticDynamics:
             )
         )
 
-        # ToDo: Due to DaCe VRAM pooling creating a memory
-        # leak with the usage pattern of those two fields (to be fixed soon)
+        # TODO (floriand): Due to DaCe VRAM pooling creating a memory
+        # leak with the usage pattern of those two fields
         # We use the C_SW internal to workaround it e.g.:
         #  - self.cgrid_shallow_water_lagrangian_dynamics.delpc
         #  - self.cgrid_shallow_water_lagrangian_dynamics.ptc
+        # DaCe has already a fix on their side and it awaits release
+        # issue 
         # self.delpc = utils.make_storage_from_shape(
         #     grid_indexing.domain_full(add=(1, 1, 1)),
         #     backend=stencil_factory.backend,

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -575,7 +575,7 @@ class AcousticDynamics:
         #  - self.cgrid_shallow_water_lagrangian_dynamics.delpc
         #  - self.cgrid_shallow_water_lagrangian_dynamics.ptc
         # DaCe has already a fix on their side and it awaits release
-        # issue 
+        # issue
         # self.delpc = utils.make_storage_from_shape(
         #     grid_indexing.domain_full(add=(1, 1, 1)),
         #     backend=stencil_factory.backend,

--- a/fv3core/pace/fv3core/stencils/fillz.py
+++ b/fv3core/pace/fv3core/stencils/fillz.py
@@ -130,7 +130,7 @@ class FillNegativeTracerValues:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=["tracers"],
+            dace_compiletime_args=["tracers"],
         )
         self._nq = int(nq)
         self._fix_tracer_stencil = stencil_factory.from_origin_domain(

--- a/fv3core/pace/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/pace/fv3core/stencils/fv_dynamics.py
@@ -12,7 +12,7 @@ import pace.util.constants as constants
 from pace.dsl.dace.orchestration import dace_inhibitor, orchestrate
 from pace.dsl.dace.wrapped_halo_exchange import WrappedHaloUpdater
 from pace.dsl.stencil import StencilFactory
-from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
+from pace.dsl.typing import FloatField, FloatFieldK
 from pace.fv3core._config import DynamicalCoreConfig
 from pace.fv3core.initialization.dycore_state import DycoreState
 from pace.fv3core.stencils import fvtp2d, tracer_2d_1l
@@ -332,6 +332,11 @@ class DynamicalCore:
         self._conserve_total_energy = config.consv_te
         self._timestep = timestep.total_seconds()
 
+    # See divergence_damping.py, _get_da_min for explanation of this function
+    @dace_inhibitor
+    def _get_da_min(self) -> float:
+        return self._da_min
+
     def _checkpoint_fvdynamics(self, state: DycoreState, tag: str):
         if self.call_checkpointer:
             self.checkpointer(
@@ -483,7 +488,7 @@ class DynamicalCore:
                     self.post_remap(
                         state,
                         is_root_rank=self.comm_rank == 0,
-                        da_min=self._da_min,
+                        da_min=self._get_da_min(),
                     )
         self.wrapup(
             state,
@@ -531,7 +536,7 @@ class DynamicalCore:
         self,
         state: DycoreState,
         is_root_rank: bool,
-        da_min: FloatFieldIJ,
+        da_min: float,
     ):
         if not self.config.hydrostatic:
             if __debug__:

--- a/fv3core/pace/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/pace/fv3core/stencils/mapn_tracer.py
@@ -29,7 +29,7 @@ class MapNTracer:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=["tracers"],
+            dace_compiletime_args=["tracers"],
         )
         grid_indexing = stencil_factory.grid_indexing
         self._origin = (i1, j1, 0)

--- a/fv3core/pace/fv3core/stencils/remapping.py
+++ b/fv3core/pace/fv3core/stencils/remapping.py
@@ -290,7 +290,7 @@ class LagrangianToEulerian:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=["tracers"],
+            dace_compiletime_args=["tracers"],
         )
         grid_indexing = stencil_factory.grid_indexing
         if config.kord_tm >= 0:

--- a/fv3core/pace/fv3core/stencils/riem_solver3.py
+++ b/fv3core/pace/fv3core/stencils/riem_solver3.py
@@ -194,7 +194,7 @@ class RiemannSolver3:
         cappa: FloatField,
         ptop: float,
         zs: FloatFieldIJ,
-        wsd: FloatField,
+        wsd: FloatFieldIJ,
         delz: FloatField,
         q_con: FloatField,
         delp: FloatField,

--- a/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
@@ -187,7 +187,7 @@ class TracerAdvection:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=["tracers"],
+            dace_compiletime_args=["tracers"],
         )
         grid_indexing = stencil_factory.grid_indexing
         self.grid_indexing = grid_indexing  # needed for selective validation

--- a/fv3core/pace/fv3core/stencils/updatedzd.py
+++ b/fv3core/pace/fv3core/stencils/updatedzd.py
@@ -3,6 +3,7 @@ from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import pace.dsl.gt4py_utils as utils
 import pace.util.constants as constants
+from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import GridIndexing, StencilFactory
 from pace.dsl.typing import FloatField, FloatFieldIJ, FloatFieldK
 from pace.fv3core.stencils.delnflux import DelnFluxNoSG
@@ -207,6 +208,10 @@ class UpdateHeightOnDGrid:
                 can be used as an approximation
             column_namelist: dictionary of parameter columns
         """
+        orchestrate(
+            obj=self,
+            config=stencil_factory.config.dace_config,
+        )
         grid_indexing = stencil_factory.grid_indexing
         self.grid_indexing = grid_indexing
         self._area = grid_data.area
@@ -245,11 +250,6 @@ class UpdateHeightOnDGrid:
             origin=grid_indexing.origin_compute(),
             domain=grid_indexing.domain_compute(add=(0, 0, 1)),
         )
-        # self._set_nans = get_set_nan_func(
-        #     grid_indexing,
-        #     dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
-        #     n_halo=((0, 0), (0, 0)),
-        # )
 
     def _allocate_temporary_storages(self, grid_indexing: GridIndexing, backend: str):
         largest_possible_shape = grid_indexing.domain_full(add=(1, 1, 1))
@@ -398,4 +398,3 @@ class UpdateHeightOnDGrid:
             ws,
             dt,
         )
-        # self._set_nans(height)

--- a/fv3core/pace/fv3core/testing/translate_dyncore.py
+++ b/fv3core/pace/fv3core/testing/translate_dyncore.py
@@ -171,6 +171,7 @@ class TranslateDynCore(ParallelTranslate2PyState):
             config=DynamicalCoreConfig.from_namelist(self.namelist).acoustic_dynamics,
             pfull=inputs["pfull"],
             phis=inputs["phis"],
+            wsd=wsd.storage,
             state=state,
         )
         acoustic_dynamics.cappa.storage[:] = inputs["cappa"][:]

--- a/fv3core/pace/fv3core/testing/translate_dyncore.py
+++ b/fv3core/pace/fv3core/testing/translate_dyncore.py
@@ -176,7 +176,7 @@ class TranslateDynCore(ParallelTranslate2PyState):
         )
         acoustic_dynamics.cappa.storage[:] = inputs["cappa"][:]
 
-        acoustic_dynamics(state, wsd=wsd, timestep=inputs["mdt"], n_map=state.n_map)
+        acoustic_dynamics(state, timestep=inputs["mdt"], n_map=state.n_map)
         # the "inputs" dict is not used to return, we construct a new dict based
         # on variables attached to `state`
         storages_only = {}

--- a/fv3core/tests/savepoint/translate/translate_a2b_ord4.py
+++ b/fv3core/tests/savepoint/translate/translate_a2b_ord4.py
@@ -13,7 +13,7 @@ class A2B_Ord4Compute:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=["divdamp"],
+            dace_compiletime_args=["divdamp"],
         )
 
     def __call__(self, divdamp, wk, vort, delpc, dt):

--- a/physics/pace/physics/stencils/microphysics.py
+++ b/physics/pace/physics/stencils/microphysics.py
@@ -1905,7 +1905,7 @@ class Microphysics:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=["state"],
+            dace_compiletime_args=["state"],
         )
 
         self.namelist = namelist
@@ -2109,7 +2109,7 @@ class Microphysics:
         pie = 4.0 * np.arctan(1.0)
 
         # S. Klein's formular (eq 16) from am2
-        fac_rc = (4.0 / 3.0) * pie * functions.RHOR * self.namelist.rthresh ** 3
+        fac_rc = (4.0 / 3.0) * pie * functions.RHOR * self.namelist.rthresh**3
 
         vdifu = 2.11e-5
         tcond = 2.36e-2
@@ -2174,7 +2174,7 @@ class Microphysics:
             / act[0] ** 0.65625
         )
         cssub[3] = tcond * constants.RVGAS
-        cssub[4] = (hlts ** 2) * vdifu
+        cssub[4] = (hlts**2) * vdifu
 
         cgsub = numpy_module.empty(5)
         cgsub[0] = 2.0 * pie * vdifu * tcond * constants.RVGAS * rnzg
@@ -2190,7 +2190,7 @@ class Microphysics:
             0.31 * scm3 * gam290 * np.sqrt(self.namelist.alin / visk) / act[1] ** 0.725
         )
         crevp[3] = cssub[3]
-        crevp[4] = hltc ** 2 * vdifu
+        crevp[4] = hltc**2 * vdifu
 
         cgfr = numpy_module.empty(2)
         cgfr[0] = 20.0e2 * pisq * rnzr * functions.RHOR / act[1] ** 1.75

--- a/physics/pace/physics/stencils/microphysics.py
+++ b/physics/pace/physics/stencils/microphysics.py
@@ -2109,7 +2109,7 @@ class Microphysics:
         pie = 4.0 * np.arctan(1.0)
 
         # S. Klein's formular (eq 16) from am2
-        fac_rc = (4.0 / 3.0) * pie * functions.RHOR * self.namelist.rthresh**3
+        fac_rc = (4.0 / 3.0) * pie * functions.RHOR * self.namelist.rthresh ** 3
 
         vdifu = 2.11e-5
         tcond = 2.36e-2
@@ -2174,7 +2174,7 @@ class Microphysics:
             / act[0] ** 0.65625
         )
         cssub[3] = tcond * constants.RVGAS
-        cssub[4] = (hlts**2) * vdifu
+        cssub[4] = (hlts ** 2) * vdifu
 
         cgsub = numpy_module.empty(5)
         cgsub[0] = 2.0 * pie * vdifu * tcond * constants.RVGAS * rnzg
@@ -2190,7 +2190,7 @@ class Microphysics:
             0.31 * scm3 * gam290 * np.sqrt(self.namelist.alin / visk) / act[1] ** 0.725
         )
         crevp[3] = cssub[3]
-        crevp[4] = hltc**2 * vdifu
+        crevp[4] = hltc ** 2 * vdifu
 
         cgfr = numpy_module.empty(2)
         cgfr[0] = 20.0e2 * pisq * rnzr * functions.RHOR / act[1] ** 1.75

--- a/physics/pace/physics/stencils/physics.py
+++ b/physics/pace/physics/stencils/physics.py
@@ -179,7 +179,7 @@ class Physics:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=["physics_state"],
+            dace_compiletime_args=["physics_state"],
         )
 
         grid_indexing = stencil_factory.grid_indexing

--- a/stencils/pace/stencils/fv_update_phys.py
+++ b/stencils/pace/stencils/fv_update_phys.py
@@ -95,7 +95,7 @@ class ApplyPhysicsToDycore:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=["state"],
+            dace_compiletime_args=["state"],
         )
         grid_indexing = stencil_factory.grid_indexing
         self.comm = comm

--- a/stencils/pace/stencils/update_atmos_state.py
+++ b/stencils/pace/stencils/update_atmos_state.py
@@ -156,7 +156,7 @@ class DycoreToPhysics:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=["dycore_state", "physics_state", "tendency_state"],
+            dace_compiletime_args=["dycore_state", "physics_state", "tendency_state"],
         )
 
         self._copy_dycore_to_physics = stencil_factory.from_dims_halo(
@@ -251,7 +251,7 @@ class UpdateAtmosphereState:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
-            dace_constant_args=[
+            dace_compiletime_args=[
                 "dycore_state",
                 "phy_state",
             ],


### PR DESCRIPTION
## Purpose

This PR address two issues:
* `main` has broken orchestration due to the passing of `wsd` / `cappa` as quantities down the stack. A DaCe bug means that `wsd` has output only creates a memory description failure we had to get around.
* Two damping coefficients scalars `da_min` and `da_min_c` are decomposition dependent, which breaks our distributed compile system with DaCe.
* Using internal of C_SW instead of return values to workaround a memory leak happening in the pooling of DaCe.

## Code changes:
- Turn distributed compilation back on, e.g. `DEACTIVATE_DISTRIBUTED_DACE_COMPILE = False`
- `wsd` and `cappa` are now cached on the proper top-level module (fv_dyn & acoustics) and there storage are access via `self`
- See comment left in code:
```
# We need to use a getter for da_min & da_min_c in order to go around a DaCe inline
# behavior. As part of the automatic optimization process, DaCe tries to inline
# as many scalars as possible.
# The grid is _not_ passed as an input to the top level function we orchestrate,
# so its scalar values will be inlined.

# 'alas, our distributed compilation system works by compiling a 3,3 layout
# top tile, then using those 9 caches on every layout upward.
# This setup leads to the values of da_min/da_min_c from the 3,3 layout
# to be inlined in the generated code. Those variables are used in runtime
# calculation (kinetic energy, etc.) which obviously leads to misbehaving numerics
# and errors when the 3,3 layout values are used on larger layouts

# The solution we implement here is making use of the fact that callbacks
# are never inlined in dace optimization. the current workaround uses the
# following functions.

# An alternative would be to pass the Grid or the DampingCoefficients to DaCe,
# clearly flagging it has a dynamic piece of memory (which would
# cancel any inlining) but the feature to do that (dace.struct)
# is currently in disarray.
# N.B.: another solution is to pass da_min and da_min_c as input, put it seems
# odd and adds a lot of boilerplate throughout the model code.
```
- `dace_constants_args` has been renamed to `dace_compiletime_args` to match DaCe API naming change
- change in field referenced in dyn_core, see comment left in code above `self.ptc` and `self.delpc`:
```
# ToDo: Due to DaCe VRAM pooling creating a memory
# leak with the usage pattern of those two fields (to be fixed soon)
# We use the C_SW internal to workaround it e.g.:
#  - self.cgrid_shallow_water_lagrangian_dynamics.delpc
#  - self.cgrid_shallow_water_lagrangian_dynamics.ptc
```

## Requirements changes:

- N/A

## Infrastructure changes:

- N/A

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
