### PR TITLE
use correct directory for install_virtualenv

### DIFF
--- a/fv3core/.jenkins/jenkins.sh
+++ b/fv3core/.jenkins/jenkins.sh
@@ -190,7 +190,7 @@ if [ ${python_env} == "virtualenv" ]; then
     else
         echo "virtualenv ${VIRTUALENV} is not setup yet, installing now"
         export FV3CORE_INSTALL_FLAGS="-e"
-        ${JENKINS_DIR}/install_virtualenv.sh ${VIRTUALENV}
+        ${TOP_LEVEL_JENKINS_DIR}/install_virtualenv.sh ${VIRTUALENV}
     fi
     source ${VIRTUALENV}/bin/activate
     if grep -q "parallel" <<< "${script}"; then

--- a/fv3core/examples/standalone/benchmarks/run_on_daint.sh
+++ b/fv3core/examples/standalone/benchmarks/run_on_daint.sh
@@ -84,7 +84,7 @@ echo "creating the venv"
 if [ -d ./venv ] ; then rm -rf venv ; fi
 if [ -d ./gt4py ] ; then rm -rf gt4py ; fi
 cd $FV3CORE_DIR
-$FV3CORE_DIR/.jenkins/install_virtualenv.sh $FV3CORE_DIR/venv
+$PACE_DIR/.jenkins/install_virtualenv.sh $FV3CORE_DIR/venv
 source ./venv/bin/activate
 pip list
 


### PR DESCRIPTION
## Purpose

This PR fixes the daint performance plan by using the correct directory for install_virtualenv.sh, since the duplicate copy under the fv3core directory has been deleted.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
