### PR TITLE
Fix caching of gt_cache directories on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
             TEST_ARGS="--backend=<<parameters.backend>> -v -s" DEV=y make savepoint_tests_mpi
           no_output_timeout: 3h
       - save_cache:
-          key: v12-gt_cache-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+          key: v2-gt_cache-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
           paths:
             - .gt_cache
             - .gt_cache_000000

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           command: git submodule status external/gt4py | awk '{print $1;}' > gt4py_version.txt
       - restore_cache:
           keys:
-            - v2-gt_cache-serial-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+            - v3-gt_cache-serial-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
             - v1-savepoints-{{ checksum "Makefile.data_download" }}
       - run:
           name: build image
@@ -100,9 +100,10 @@ jobs:
             TEST_ARGS="--backend=<<parameters.backend>> -v -s" DEV=y make savepoint_tests
           no_output_timeout: 3h
       - save_cache:
-          key: v2-gt_cache-serial-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+          key: v3-gt_cache-serial-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
           paths:
             - .gt_cache
+            - .gt_cache_000000
       - save_cache:
           key: v1-savepoints-{{ checksum "Makefile.data_download" }}
           paths:
@@ -147,6 +148,10 @@ jobs:
           name: build image
           command: |
             BUILD_ARGS="--progress=plain" DEV=n make build
+      - run:
+          name: download GridTools sources
+          command: |
+            PYTHONPATH=./external/gt4py/src python3 -m gt4py.gt_src_manager install
       - run:
           name: run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           command: git submodule status external/gt4py | awk '{print $1;}' > gt4py_version.txt
       - restore_cache:
           keys:
-            - v1-gt_cache-serial-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+            - v2-gt_cache-serial-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
             - v1-savepoints-{{ checksum "Makefile.data_download" }}
       - run:
           name: build image
@@ -97,10 +97,10 @@ jobs:
       - run:
           name: run tests
           command: |
-            TEST_ARGS="--backend=<<parameters.backend>> -v -s" DEV=n make savepoint_tests
+            TEST_ARGS="--backend=<<parameters.backend>> -v -s" DEV=y make savepoint_tests
           no_output_timeout: 3h
       - save_cache:
-          key: v1-gt_cache-serial-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+          key: v2-gt_cache-serial-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
           paths:
             - .gt_cache
       - save_cache:
@@ -139,7 +139,9 @@ jobs:
           command: git submodule status external/gt4py | awk '{print $1;}' > gt4py_version.txt
       - restore_cache:
           keys:
-            - v1-gt_cache-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+            - v2-gt_cache-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+      - restore_cache:
+          keys:
             - v1-savepoints-{{ checksum "Makefile.data_download" }}
       - run:
           name: build image
@@ -148,10 +150,10 @@ jobs:
       - run:
           name: run tests
           command: |
-            TEST_ARGS="--backend=<<parameters.backend>> -v -s" DEV=n make savepoint_tests_mpi
+            TEST_ARGS="--backend=<<parameters.backend>> -v -s" DEV=y make savepoint_tests_mpi
           no_output_timeout: 3h
       - save_cache:
-          key: v1-gt_cache-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+          key: v12-gt_cache-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
           paths:
             - .gt_cache
             - .gt_cache_000000

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,8 @@ jobs:
       - restore_cache:
           keys:
             - v3-gt_cache-serial-<<parameters.backend>>-{{ checksum "gt4py_version.txt" }}
+      - restore_cache:
+          keys:
             - v1-savepoints-{{ checksum "Makefile.data_download" }}
       - run:
           name: build image
@@ -148,10 +150,6 @@ jobs:
           name: build image
           command: |
             BUILD_ARGS="--progress=plain" DEV=n make build
-      - run:
-          name: download GridTools sources
-          command: |
-            PYTHONPATH=./external/gt4py/src python3 -m gt4py.gt_src_manager install
       - run:
           name: run tests
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ RUN apt-get update && apt-get install -y make \
     netcdf-bin \
     libnetcdf-dev \
     python3 \
-    python3-pip \
-    git
+    python3-pip
 
-RUN git config --global http.sslverify false && \
-    pip3 install --upgrade setuptools wheel
+RUN pip3 install --upgrade setuptools wheel
 
 COPY . /pace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,11 @@ RUN apt-get update && apt-get install -y make \
     netcdf-bin \
     libnetcdf-dev \
     python3 \
-    python3-pip
+    python3-pip \
+    git
 
-RUN pip3 install --upgrade setuptools wheel
+RUN git config --global http.sslverify false && \
+    pip3 install --upgrade setuptools wheel
 
 COPY . /pace
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ PULL ?=True
 DEV ?=y
 CHECK_CHANGED_SCRIPT=$(CWD)/changed_from_main.py
 CONTAINER_CMD?=docker
+SAVEPOINT_SETUP=pip3 list && python3 -m gt4py.gt_src_manager install
 
 VOLUMES ?=
 
@@ -103,11 +104,11 @@ test_util:
 
 savepoint_tests: build
 	TARGET=dycore $(MAKE) get_test_data
-	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "pip3 list && cd $(PACE_PATH) && pytest --data_path=$(EXPERIMENT_DATA_RUN)/dycore/ $(TEST_ARGS) $(FV3CORE_THRESH_ARGS) $(PACE_PATH)/fv3core/tests/savepoint"
+	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "$(SAVEPOINT_SETUP) && cd $(PACE_PATH) && pytest --data_path=$(EXPERIMENT_DATA_RUN)/dycore/ $(TEST_ARGS) $(FV3CORE_THRESH_ARGS) $(PACE_PATH)/fv3core/tests/savepoint"
 
 savepoint_tests_mpi: build
 	TARGET=dycore $(MAKE) get_test_data
-	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "pip3 list && cd $(PACE_PATH) && $(MPIRUN_CALL) python3 -m mpi4py -m pytest --maxfail=1 --data_path=$(EXPERIMENT_DATA_RUN)/dycore/ $(TEST_ARGS) $(FV3CORE_THRESH_ARGS) -m parallel $(PACE_PATH)/fv3core/tests/savepoint"
+	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "$(SAVEPOINT_SETUP) && cd $(PACE_PATH) && $(MPIRUN_CALL) python3 -m mpi4py -m pytest --maxfail=1 --data_path=$(EXPERIMENT_DATA_RUN)/dycore/ $(TEST_ARGS) $(FV3CORE_THRESH_ARGS) -m parallel $(PACE_PATH)/fv3core/tests/savepoint"
 
 dependencies.svg: dependencies.dot
 	dot -Tsvg $< -o $@
@@ -119,21 +120,21 @@ constraints.txt: driver/setup.py dsl/setup.py fv3core/setup.py physics/setup.py 
 
 physics_savepoint_tests: build
 	TARGET=physics $(MAKE) get_test_data
-	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "pip3 list && cd $(PACE_PATH) && pytest --data_path=$(EXPERIMENT_DATA_RUN)/physics/ $(TEST_ARGS) $(PHYSICS_THRESH_ARGS) $(PACE_PATH)/physics/tests/savepoint"
+	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "$(SAVEPOINT_SETUP) && cd $(PACE_PATH) && pytest --data_path=$(EXPERIMENT_DATA_RUN)/physics/ $(TEST_ARGS) $(PHYSICS_THRESH_ARGS) $(PACE_PATH)/physics/tests/savepoint"
 
 physics_savepoint_tests_mpi: build
 	TARGET=physics $(MAKE) get_test_data
-	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "pip3 list && cd $(PACE_PATH) && $(MPIRUN_CALL) python -m mpi4py -m pytest --maxfail=1 --data_path=$(EXPERIMENT_DATA_RUN)/physics/ $(TEST_ARGS) $(PHYSICS_THRESH_ARGS) -m parallel $(PACE_PATH)/physics/tests/savepoint"
+	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "$(SAVEPOINT_SETUP) && cd $(PACE_PATH) && $(MPIRUN_CALL) python -m mpi4py -m pytest --maxfail=1 --data_path=$(EXPERIMENT_DATA_RUN)/physics/ $(TEST_ARGS) $(PHYSICS_THRESH_ARGS) -m parallel $(PACE_PATH)/physics/tests/savepoint"
 
 test_main: build
-	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "pip3 list && cd $(PACE_PATH) && pytest $(TEST_ARGS) $(PACE_PATH)/tests/main"
+	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "$(SAVEPOINT_SETUP) && cd $(PACE_PATH) && pytest $(TEST_ARGS) $(PACE_PATH)/tests/main"
 
 test_mpi_54rank:
 	mpirun -n 54 $(MPIRUN_ARGS) python3 -m mpi4py -m pytest tests/mpi_54rank
 
 driver_savepoint_tests_mpi: build
 	TARGET=driver $(MAKE) get_test_data
-	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "pip3 list && cd $(PACE_PATH) && $(MPIRUN_CALL) python -m mpi4py -m pytest --maxfail=1 --data_path=$(EXPERIMENT_DATA_RUN)/driver/ $(TEST_ARGS) $(PHYSICS_THRESH_ARGS) -m parallel $(PACE_PATH)/physics/tests/savepoint"
+	$(CONTAINER_CMD) $(CONTAINER_FLAGS) bash -c "$(SAVEPOINT_SETUP) && cd $(PACE_PATH) && $(MPIRUN_CALL) python -m mpi4py -m pytest --maxfail=1 --data_path=$(EXPERIMENT_DATA_RUN)/driver/ $(TEST_ARGS) $(PHYSICS_THRESH_ARGS) -m parallel $(PACE_PATH)/physics/tests/savepoint"
 
 docs: ## generate Sphinx HTML documentation
 	$(MAKE) -C docs html


### PR DESCRIPTION
## Purpose

This PR fixes an issue where gt4py cache directories were not cached between executions on CircleCI.

## Infrastructure changes:

- Savepoint make targets now run `python3 -m gt4py.gt_src_manager install` before running tests inside docker, to avoid issues arising from git cloning these sources in a MPI-parallel context

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
