### PR TITLE
Improve Circleci docker build times through caching

### DIFF
--- a/.circleci/build_and_push_image.sh
+++ b/.circleci/build_and_push_image.sh
@@ -26,7 +26,6 @@ echo $BUILD_IMAGE
 BUILD_FLAGS=" \
     --secret id=gcp,src=$GOOGLE_APPLICATION_CREDENTIALS \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --build-arg COMMIT_SHA_ARG="$(git rev-parse HEAD)" \
     --progress=plain \
     --cache-from $CACHE_IMAGE \
 "
@@ -35,4 +34,5 @@ PACE_IMAGE="$BUILD_IMAGE" DEV=n BUILD_FLAGS="$BUILD_FLAGS" make build
 
 echo "pushing tagged images $CIRCLE_SHA1"
 docker push $BUILD_IMAGE
+docker tag $BUILD_IMAGE $CACHE_IMAGE
 docker push $CACHE_IMAGE

--- a/.circleci/build_and_push_image.sh
+++ b/.circleci/build_and_push_image.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+echo "branch: $CIRCLE_BRANCH"
+echo "tag:    $CIRCLE_TAG"
+
+set -e
+set -o pipefail
+
+if [[ -z "$CIRCLE_SHA1" ]]
+then
+    CIRCLE_SHA1=$(git rev-parse HEAD)
+fi
+
+CACHE_IMAGE="us.gcr.io/vcm-ml/pace:latest"
+BUILD_IMAGE="us.gcr.io/vcm-ml/pace:$CIRCLE_SHA1"
+
+if [[ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]]
+then
+    echo "Google authentication not configured. "
+    echo "Please set the GOOGLE_APPLICATION_CREDENTIALS environmental variable."
+    exit 1
+fi
+
+echo $BUILD_IMAGE
+
+BUILD_FLAGS=" \
+    --secret id=gcp,src=$GOOGLE_APPLICATION_CREDENTIALS \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --build-arg COMMIT_SHA_ARG="$(git rev-parse HEAD)" \
+    --progress=plain \
+    --cache-from $CACHE_IMAGE \
+"
+
+PACE_IMAGE="$BUILD_IMAGE" DEV=n BUILD_FLAGS="$BUILD_FLAGS" make build
+
+echo "pushing tagged images $CIRCLE_SHA1"
+docker push $BUILD_IMAGE
+docker push $CACHE_IMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,14 +48,13 @@ commands:
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
             gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
             gcloud auth configure-docker
-      - checkout
       - run:
           name: Update Submodules
           command: git submodule update --init
       - run:
           name: build image
           command: |
-            BUILD_ARGS="--progress=plain" DEV=n make build
+            .circleci/build_and_push_image.sh
   restore_gt_cache:
     description: "Restore .gt_cache"
     parameters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.8.13-bullseye@sha256:2a01d88a1684e6d7f08030cf5ae73b536926c64076cab197e9e3d9f699255283
 
-
 RUN apt-get update && apt-get install -y make \
     software-properties-common \
     libopenmpi3 \
@@ -13,6 +12,10 @@ RUN apt-get update && apt-get install -y make \
     python3-pip
 
 RUN pip3 install --upgrade setuptools wheel
+
+COPY constraints.txt /pace/constraints.txt
+
+RUN pip3 install -r /pace/constraints.txt
 
 COPY . /pace
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ CONTAINER_CMD?=docker
 SAVEPOINT_SETUP=pip3 list && python3 -m gt4py.gt_src_manager install
 
 VOLUMES ?=
+BUILD_FLAGS ?=
 
 ### Testing variables
 
@@ -83,6 +84,7 @@ endif
 
 _force_build:
 	DOCKER_BUILDKIT=1 docker build \
+		$(BUILD_FLAGS) \
 		-f $(CWD)/Dockerfile \
 		-t $(PACE_IMAGE) \
 		.


### PR DESCRIPTION
## Purpose

This PR speeds up CircleCI builds by caching docker layers remotely.

## Infrastructure changes:

- Images for every commit are now pushed to GCR
- CircleCI now uses the latest GCR image as a cache when building

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes
