### PR TITLE
Fix microphysics issue for non-orchestrated GPU backend

### DIFF
--- a/physics/pace/physics/stencils/microphysics.py
+++ b/physics/pace/physics/stencils/microphysics.py
@@ -1906,8 +1906,12 @@ class Microphysics:
         )
 
         self.namelist = namelist
-        # Cache a numpy-like module for
-        if stencil_factory.config.is_gpu_backend:
+        # In orchestration mode, we pass the device memory
+        # TODO: turn arrays in setupm into a dataclass, or inidivudal scalars
+        if (
+            stencil_factory.config.is_gpu_backend
+            and stencil_factory.config.dace_config.is_dace_orchestrated()
+        ):
             self.gfdl_cloud_microphys_init(cp)
         else:
             self.gfdl_cloud_microphys_init(np)

--- a/physics/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/physics/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -34,3 +34,10 @@ Microph:
       mph_ql_dt: 1e-8
       mph_qr_dt: 1e-9
       mph_qg_dt: 1e-18
+  - backend: dace:gpu
+    max_error: 2.2e-8
+    cuda_no_fma: true
+    ignore_near_zero_errors:
+      mph_ql_dt: 1e-8
+      mph_qr_dt: 1e-9
+      mph_qg_dt: 1e-18

--- a/physics/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/physics/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -16,6 +16,8 @@ GFSPhysicsDriver:
     cuda_no_fma: true
   - backend: gt:gpu
     cuda_no_fma: true
+  - backend: dace:gpu
+    cuda_no_fma: true
 
 # On GPU u/v wind tendencies seems to diverge in computation from numpy/fortran
 # equivalent due to the use of fused multiply-add in the update stencil.

--- a/physics/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/physics/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -18,6 +18,10 @@ GFSPhysicsDriver:
     cuda_no_fma: true
   - backend: dace:gpu
     cuda_no_fma: true
+    ignore_near_zero_errors:
+      IPD_rain: 1e-12
+      IPD_qice: 1e-12
+      IPD_qgraupel: 1e-12
 
 # On GPU u/v wind tendencies seems to diverge in computation from numpy/fortran
 # equivalent due to the use of fused multiply-add in the update stencil.
@@ -43,3 +47,5 @@ Microph:
       mph_ql_dt: 1e-8
       mph_qr_dt: 1e-9
       mph_qg_dt: 1e-18
+      mph_udt: 1e-8
+      mph_vdt: 1e-8


### PR DESCRIPTION
## Purpose

This PR fixes #257.

## Code changes:

- `microphysics.py`: use `cp` only in orchestrated mode, regular gpu backend needs to be numpy because we cannot direct index cupy array

## Infrastructure changes:

- Physics `dace:gpu` savepoint tests are now enabled on daint, all other backends are not tested through jenkins anymore since they are tested as part of circleci.

## Checklist
- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes

