### PR TITLE
Optimize column integral calculation 

### DIFF
--- a/driver/pace/driver/diagnostics.py
+++ b/driver/pace/driver/diagnostics.py
@@ -4,8 +4,6 @@ import warnings
 from datetime import datetime, timedelta
 from typing import List, Optional, Union
 
-from sympy import ShapeError
-
 import pace.driver
 import pace.dsl
 import pace.stencils
@@ -174,13 +172,13 @@ def _compute_column_integral(
         q_in: tracer mixing ratio
         delp: pressure thickness of atmospheric layer
     """
-    if len(q_in.shape) < 3:
-        assert ShapeError(f"{name} does not have vertical levels.")
+    if q_in.dims[2] != pace.util.Z_DIM:
+        raise NotImplementedError(
+            "this function assumes the z-dimension is the third dimension"
+        )
+    k_slice = slice(q_in.origin[2], q_in.origin[2] + q_in.extent[2])
     column_integral = pace.util.Quantity(
-        q_in.np.sum(
-            q_in.data[:, :, k] * delp.data[:, :, k]
-            for k in range(q_in.metadata.extent[2])
-        ),
+        q_in.np.sum(q_in.data[:, :, k_slice] * delp.data[:, :, k_slice], axis=2),
         dims=("x", "y"),
         origin=q_in.metadata.origin[0:2],
         extent=(q_in.metadata.extent[0], q_in.metadata.extent[1]),

--- a/driver/pace/driver/diagnostics.py
+++ b/driver/pace/driver/diagnostics.py
@@ -177,7 +177,7 @@ def _compute_column_integral(
     if len(q_in.shape) < 3:
         assert ShapeError(f"{name} does not have vertical levels.")
     column_integral = pace.util.Quantity(
-        sum(
+        q_in.np.sum(
             q_in.data[:, :, k] * delp.data[:, :, k]
             for k in range(q_in.metadata.extent[2])
         ),

--- a/driver/pace/driver/diagnostics.py
+++ b/driver/pace/driver/diagnostics.py
@@ -172,6 +172,7 @@ def _compute_column_integral(
         q_in: tracer mixing ratio
         delp: pressure thickness of atmospheric layer
     """
+    assert len(q_in.dims) > 2
     if q_in.dims[2] != pace.util.Z_DIM:
         raise NotImplementedError(
             "this function assumes the z-dimension is the third dimension"


### PR DESCRIPTION
## Purpose

This PR makes the calculation of column integrated tracers faster.

## Code changes:

- diagnostics: use quantity np sum instead of native python sum

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes

