### PR TITLE
Fix column integral dimension

### DIFF
--- a/driver/pace/driver/diagnostics.py
+++ b/driver/pace/driver/diagnostics.py
@@ -180,7 +180,7 @@ def _compute_column_integral(
     k_slice = slice(q_in.origin[2], q_in.origin[2] + q_in.extent[2])
     column_integral = pace.util.Quantity(
         q_in.np.sum(q_in.data[:, :, k_slice] * delp.data[:, :, k_slice], axis=2),
-        dims=("x", "y"),
+        dims=tuple(q_in.dims[:2]) + tuple(q_in.dims[3:]),
         origin=q_in.metadata.origin[0:2],
         extent=(q_in.metadata.extent[0], q_in.metadata.extent[1]),
         units="kg/m**2",


### PR DESCRIPTION

## Purpose

Quick fix to diagnostics to better speicfy column integral dimension.

## Code changes:

- diagnostics: dims uses input quanity metadata 

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes
