### PR TITLE
Add week of year to gt_cache circleci cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
           command: date +"week_%U_of_%Y" > week.txt
       - restore_cache:
           keys:
-            - v4-gt_cache-<<parameters.key>>-{{ checksum "gt4py_version.txt" }}-{{ cat "week.txt"}}
+            - v4-gt_cache-<<parameters.key>>-{{ checksum "gt4py_version.txt" }}-{{ checksum "week.txt"}}
   save_gt_cache:
     description: "Save .gt_cache"
     parameters:
@@ -77,7 +77,7 @@ commands:
         type: string
     steps:
       - save_cache:
-          key: v4-gt_cache-<<parameters.key>>-{{ checksum "gt4py_version.txt" }}-{{ cat "week.txt"}}
+          key: v4-gt_cache-<<parameters.key>>-{{ checksum "gt4py_version.txt" }}-{{ checksum "week.txt"}}
           paths:
             - .gt_cache
   make_savepoints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,6 +460,13 @@ jobs:
 workflows:
   version: 2
   tagged-build:
+    triggers:
+      - schedule:
+          cron: "15 3 * * 0"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - lint:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,12 @@ commands:
       - run:
           name: save gt4py_version.txt
           command: git submodule status external/gt4py | awk '{print $1;}' > gt4py_version.txt
+      - run:
+          name: save week.txt
+          command: date +"week_%U_of_%Y" > week.txt
       - restore_cache:
           keys:
-            - v4-gt_cache-<<parameters.key>>-{{ checksum "gt4py_version.txt" }}
+            - v4-gt_cache-<<parameters.key>>-{{ checksum "gt4py_version.txt" }}-{{ cat "week.txt"}}
   save_gt_cache:
     description: "Save .gt_cache"
     parameters:
@@ -74,7 +77,7 @@ commands:
         type: string
     steps:
       - save_cache:
-          key: v4-gt_cache-<<parameters.key>>-{{ checksum "gt4py_version.txt" }}
+          key: v4-gt_cache-<<parameters.key>>-{{ checksum "gt4py_version.txt" }}-{{ cat "week.txt"}}
           paths:
             - .gt_cache
   make_savepoints:
@@ -356,22 +359,16 @@ jobs:
           name: Install Submodules
           command: git submodule update --init
       - setup_environment_mpi
-      - run:
-          name: save gt4py_version.txt
-          command: git submodule status external/gt4py | awk '{print $1;}' > gt4py_version.txt
-      - restore_cache:
-          keys:
-            - v1-gt_cache_driver-{{ checksum "gt4py_version.txt" }}
+      - restore_gt_cache:
+          key: v1-gt_cache_driver
       - run:
           name: run tests
           command: |
             . venv/bin/activate
             cd driver
             GT_CACHE_ROOT=$(pwd)/.gt_cache MPIRUN_CALL="mpirun -n 6 --mca btl_vader_single_copy_mechanism none" make test_mpi
-      - save_cache:
-          key: v1-gt_cache_driver-{{ checksum "gt4py_version.txt" }}
-          paths:
-            - .gt_cache
+      - save_gt_cache:
+          key: v1-gt_cache_driver
 
   test_driver_orch_cpu:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,13 +460,6 @@ jobs:
 workflows:
   version: 2
   tagged-build:
-    triggers:
-      - schedule:
-          cron: "15 3 * * 0"
-          filters:
-            branches:
-              only:
-                - main
     jobs:
       - lint:
           filters:


### PR DESCRIPTION
## Purpose

Caching of gt4py caches on CircleCI currently only invalidates the cache if the gt4py version changes. However, caches become unusable as soon as code changes.

This PR updates the caching so that caches invalidate weekly. This should ensure that caches are at least valid on main at the start of the week, and speed up test execution, at the cost of needing to rebuild the caches at the start of the week.

## Infrastructure changes:

- Updated CircleCI gt4py cache caching so that caches invalidate weekly

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
