### PR TITLE
Save one file per tile in NetCDFMonitor

### DIFF
--- a/util/pace/util/local_comm.py
+++ b/util/pace/util/local_comm.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-from enum import Enum
 from typing import Any
 
 from .comm import Comm
@@ -25,19 +24,12 @@ class AsyncResult:
         return self._result()
 
 
-class SplitState(Enum):
-    NO_SPLIT = 0
-    SPLITTING = 1
-    ALREADY_SPLIT = 2
-
-
 class LocalComm(Comm):
     def __init__(self, rank, total_ranks, buffer_dict):
         self.rank = rank
         self.total_ranks = total_ranks
         self._buffer = buffer_dict
         self._i_buffer = {}
-        self._split_state = SplitState.NO_SPLIT
 
     @property
     def _split_comms(self):

--- a/util/pace/util/local_comm.py
+++ b/util/pace/util/local_comm.py
@@ -30,8 +30,16 @@ class LocalComm(Comm):
         self.total_ranks = total_ranks
         self._buffer = buffer_dict
         self._i_buffer = {}
-        self._split_comms = {}
-        self._split_buffers = {}
+
+    @property
+    def _split_comms(self):
+        self._buffer["split_comms"] = self._buffer.get("split_comms", {})
+        return self._buffer["split_comms"]
+
+    @property
+    def _split_buffers(self):
+        self._buffer["split_buffers"] = self._buffer.get("split_buffers", {})
+        return self._buffer["split_buffers"]
 
     def __repr__(self):
         return f"LocalComm(rank={self.rank}, total_ranks={self.total_ranks})"
@@ -87,6 +95,8 @@ class LocalComm(Comm):
     def _gather_buffer(self):
         if "gather" not in self._buffer:
             self._buffer["gather"] = [None for i in range(self.total_ranks)]
+        while len(self._buffer["gather"]) < self.total_ranks:
+            self._buffer["gather"].append(None)
         return self._buffer["gather"]
 
     def bcast(self, value, root=0):

--- a/util/pace/util/local_comm.py
+++ b/util/pace/util/local_comm.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from enum import Enum
 from typing import Any
 
 from .comm import Comm
@@ -24,12 +25,19 @@ class AsyncResult:
         return self._result()
 
 
+class SplitState(Enum):
+    NO_SPLIT = 0
+    SPLITTING = 1
+    ALREADY_SPLIT = 2
+
+
 class LocalComm(Comm):
     def __init__(self, rank, total_ranks, buffer_dict):
         self.rank = rank
         self.total_ranks = total_ranks
         self._buffer = buffer_dict
         self._i_buffer = {}
+        self._split_state = SplitState.NO_SPLIT
 
     @property
     def _split_comms(self):
@@ -95,8 +103,6 @@ class LocalComm(Comm):
     def _gather_buffer(self):
         if "gather" not in self._buffer:
             self._buffer["gather"] = [None for i in range(self.total_ranks)]
-        while len(self._buffer["gather"]) < self.total_ranks:
-            self._buffer["gather"].append(None)
         return self._buffer["gather"]
 
     def bcast(self, value, root=0):

--- a/util/pace/util/monitor/netcdf_monitor.py
+++ b/util/pace/util/monitor/netcdf_monitor.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Set
 import fsspec
 import numpy as np
 
-from pace.util.communicator import CubedSphereCommunicator
+from pace.util.communicator import Communicator
 
 from .. import _xarray as xr
 from ..filesystem import get_fs
@@ -109,7 +109,7 @@ class NetCDFMonitor:
     def __init__(
         self,
         path: str,
-        communicator: CubedSphereCommunicator,
+        communicator: Communicator,
         time_chunk_size: int = 1,
     ):
         """Create a NetCDFMonitor.

--- a/util/tests/test_netcdf_monitor.py
+++ b/util/tests/test_netcdf_monitor.py
@@ -17,13 +17,18 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("layout", [(1, 1), (1, 2), (4, 4)])
-@pytest.mark.parametrize("nt, time_chunk_size", [(1, 1), (5, 2)])
+@pytest.mark.parametrize(
+    "nt, time_chunk_size",
+    [pytest.param(1, 1, id="single_time"), pytest.param(5, 2, id="chunked_time")],
+)
 @pytest.mark.parametrize(
     "shape, ny_rank_add, nx_rank_add, dims",
     [
-        ((5, 4, 4), 0, 0, ("z", "y", "x")),
-        ((5, 4, 4), 1, 1, ("z", "y_interface", "x_interface")),
-        ((5, 4, 4), 0, 1, ("z", "y", "x_interface")),
+        pytest.param((5, 4, 4), 0, 0, ("z", "y", "x"), id="cell_center"),
+        pytest.param(
+            (5, 4, 4), 1, 1, ("z", "y_interface", "x_interface"), id="cell_corner"
+        ),
+        pytest.param((5, 4, 4), 0, 1, ("z", "y", "x_interface"), id="cell_edge"),
     ],
 )
 @requires_xarray
@@ -34,11 +39,11 @@ def test_monitor_store_multi_rank_state(
     nz, ny, nx = shape
     ny_rank = int(ny / layout[0] + ny_rank_add)
     nx_rank = int(nx / layout[1] + nx_rank_add)
-    grid = pace.util.TilePartitioner(layout)
+    tile = pace.util.TilePartitioner(layout)
     time = cftime.DatetimeJulian(2010, 6, 20, 6, 0, 0)
     timestep = timedelta(hours=1)
     total_ranks = 6 * layout[0] * layout[1]
-    partitioner = pace.util.CubedSpherePartitioner(grid)
+    partitioner = pace.util.CubedSpherePartitioner(tile)
     shared_buffer = {}
     monitor_list: List[pace.util.NetCDFMonitor] = []
 
@@ -49,6 +54,9 @@ def test_monitor_store_multi_rank_state(
                 rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
             ),
         )
+        # must eagerly initialize the tile object so that their ranks are
+        # created in ascending order
+        communicator.tile
         monitor_list.append(
             pace.util.NetCDFMonitor(
                 path=tmpdir,
@@ -57,16 +65,17 @@ def test_monitor_store_multi_rank_state(
             )
         )
 
-    for rank in range(total_ranks - 1, -1, -1):
-        state = {
-            "var_const1": pace.util.Quantity(
-                numpy.ones([nz, ny_rank, nx_rank]),
-                dims=dims,
-                units=units,
-            ),
-        }
-        monitor_list[rank].store_constant(state)
+    # for rank in range(total_ranks - 1, -1, -1):
+    #     state = {
+    #         "var_const1": pace.util.Quantity(
+    #             numpy.ones([nz, ny_rank, nx_rank]),
+    #             dims=dims,
+    #             units=units,
+    #         ),
+    #     }
+    #     monitor_list[rank].store_constant(state)
 
+    tile_gathered = []
     for i_t in range(nt):
         for rank in range(total_ranks - 1, -1, -1):
             state = {
@@ -78,6 +87,9 @@ def test_monitor_store_multi_rank_state(
                 ),
             }
             monitor_list[rank].store(state)
+            tile_gathered.append(
+                monitor_list[rank]._communicator.tile.gather_state(state)
+            )
 
     for rank in range(total_ranks - 1, -1, -1):
         state = {
@@ -92,7 +104,7 @@ def test_monitor_store_multi_rank_state(
     for monitor in monitor_list:
         monitor.cleanup()
 
-    ds = xr.open_mfdataset(str(tmpdir / "state_*.nc"), decode_times=True)
+    ds = xr.open_mfdataset(str(tmpdir / "state_*_tile*.nc"), decode_times=True)
     assert "var1" in ds
     np.testing.assert_array_equal(
         ds["var1"].shape, (nt, 6, nz, ny + ny_rank_add, nx + nx_rank_add)
@@ -105,13 +117,13 @@ def test_monitor_store_multi_rank_state(
     np.testing.assert_array_equal(ds["var1"].values, 1.0)
 
     ds_const = xr.open_dataset(str(tmpdir / "constants.nc"))
-    assert "var_const1" in ds_const
-    np.testing.assert_array_equal(
-        ds_const["var_const1"].shape, (6, nz, ny + ny_rank_add, nx + nx_rank_add)
-    )
-    assert ds_const["var_const1"].dims == ("tile",) + dims
-    assert ds_const["var_const1"].attrs["units"] == units
-    np.testing.assert_array_equal(ds_const["var_const1"].values, 1.0)
+    # assert "var_const1" in ds_const
+    # np.testing.assert_array_equal(
+    #     ds_const["var_const1"].shape, (6, nz, ny + ny_rank_add, nx + nx_rank_add)
+    # )
+    # assert ds_const["var_const1"].dims == ("tile",) + dims
+    # assert ds_const["var_const1"].attrs["units"] == units
+    # np.testing.assert_array_equal(ds_const["var_const1"].values, 1.0)
     assert "var_const2" in ds_const
     np.testing.assert_array_equal(
         ds_const["var_const2"].shape, (6, nz, ny + ny_rank_add, nx + nx_rank_add)

--- a/util/tests/test_netcdf_monitor.py
+++ b/util/tests/test_netcdf_monitor.py
@@ -65,15 +65,15 @@ def test_monitor_store_multi_rank_state(
             )
         )
 
-    # for rank in range(total_ranks - 1, -1, -1):
-    #     state = {
-    #         "var_const1": pace.util.Quantity(
-    #             numpy.ones([nz, ny_rank, nx_rank]),
-    #             dims=dims,
-    #             units=units,
-    #         ),
-    #     }
-    #     monitor_list[rank].store_constant(state)
+    for rank in range(total_ranks - 1, -1, -1):
+        state = {
+            "var_const1": pace.util.Quantity(
+                numpy.ones([nz, ny_rank, nx_rank]),
+                dims=dims,
+                units=units,
+            ),
+        }
+        monitor_list[rank].store_constant(state)
 
     tile_gathered = []
     for i_t in range(nt):
@@ -117,13 +117,13 @@ def test_monitor_store_multi_rank_state(
     np.testing.assert_array_equal(ds["var1"].values, 1.0)
 
     ds_const = xr.open_dataset(str(tmpdir / "constants.nc"))
-    # assert "var_const1" in ds_const
-    # np.testing.assert_array_equal(
-    #     ds_const["var_const1"].shape, (6, nz, ny + ny_rank_add, nx + nx_rank_add)
-    # )
-    # assert ds_const["var_const1"].dims == ("tile",) + dims
-    # assert ds_const["var_const1"].attrs["units"] == units
-    # np.testing.assert_array_equal(ds_const["var_const1"].values, 1.0)
+    assert "var_const1" in ds_const
+    np.testing.assert_array_equal(
+        ds_const["var_const1"].shape, (6, nz, ny + ny_rank_add, nx + nx_rank_add)
+    )
+    assert ds_const["var_const1"].dims == ("tile",) + dims
+    assert ds_const["var_const1"].attrs["units"] == units
+    np.testing.assert_array_equal(ds_const["var_const1"].values, 1.0)
     assert "var_const2" in ds_const
     np.testing.assert_array_equal(
         ds_const["var_const2"].shape, (6, nz, ny + ny_rank_add, nx + nx_rank_add)


### PR DESCRIPTION
## Purpose

This PR refactors NetCDFMonitor so that it saves one file per tile.

## Code changes:

- NetCDFMonitor now saves one file per tile, instead of one file globally.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

