### PR TITLE
All storage temporaries are now Quantity

### DIFF
--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -470,6 +470,7 @@ class Driver:
             if not config.dycore_only and not config.disable_step_physics:
                 self.physics = pace.physics.Physics(
                     stencil_factory=self.stencil_factory,
+                    quantity_factory=self.quantity_factory,
                     grid_data=self.state.grid_data,
                     namelist=self.config.physics_config,
                     active_packages=["microphysics"],

--- a/dsl/pace/dsl/stencil.py
+++ b/dsl/pace/dsl/stencil.py
@@ -23,14 +23,12 @@ from gt4py import gtscript
 from gt4py.storage.storage import Storage
 from gtc.passes.oir_pipeline import DefaultPipeline, OirPipeline
 
-import pace.dsl.gt4py_utils as gt4py_utils
 import pace.util
 from pace.dsl.dace.orchestration import SDFGConvertible
 from pace.dsl.stencil_config import CompilationConfig, RunMode, StencilConfig
 from pace.dsl.typing import Index3D, cast_to_index3d
 from pace.util import testing
 from pace.util.decomposition import block_waiting_for_compilation, unblock_waiting_tiles
-from pace.util.halo_data_transformer import QuantityHaloSpec
 from pace.util.mpi import MPI
 
 
@@ -845,62 +843,6 @@ class GridIndexing:
         )
         new.origin = self.origin[:2] + (self.origin[2] + k_start,)
         return new
-
-    def get_quantity_halo_spec(
-        self,
-        shape: Tuple[int, ...],
-        origin: Tuple[int, ...],
-        dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
-        n_halo: Optional[int] = None,
-        *,
-        backend: str,
-    ) -> QuantityHaloSpec:
-        """Build memory specifications for the halo update.
-
-        Args:
-            shape: the shape of the Quantity
-            origin: the origin of the compute domain
-            dims: dimensionality of the data
-            n_halo: number of halo points to update, defaults to self.n_halo
-            backend: gt4py backend to use
-        """
-
-        # TEMPORARY: we do a nasty temporary allocation here to read in the hardware
-        # memory layout. Further work in GT4PY will allow for deferred allocation
-        # which will give access to those information while making sure
-        # we don't allocate
-        # Refactor is filed in ticket DSL-820
-
-        temp_storage = gt4py_utils.make_storage_from_shape(
-            shape, origin, backend=backend
-        )
-        origin, extent = self.get_origin_domain(dims)
-        temp_quantity = pace.util.Quantity(
-            temp_storage,
-            dims=dims,
-            units="unknown",
-            origin=origin,
-            extent=extent,
-        )
-        if n_halo is None:
-            n_halo = self.n_halo
-
-        spec = QuantityHaloSpec(
-            n_halo,
-            temp_quantity.data.strides,
-            temp_quantity.data.itemsize,
-            temp_quantity.data.shape,
-            temp_quantity.metadata.origin,
-            temp_quantity.metadata.extent,
-            temp_quantity.metadata.dims,
-            temp_quantity.np,
-            temp_quantity.metadata.dtype,
-        )
-
-        del temp_storage
-        del temp_quantity
-
-        return spec
 
 
 class StencilFactory:

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -231,7 +231,7 @@ class AcousticDynamics:
             self,
             comm: pace.util.CubedSphereCommunicator,
             grid_indexing: GridIndexing,
-            backend: str,
+            quantity_factory: pace.util.QuantityFactory,
             state: DycoreState,
             cappa: pace.util.Quantity,
             gz: pace.util.Quantity,
@@ -240,44 +240,27 @@ class AcousticDynamics:
             heat_source: pace.util.Quantity,
             pkc: pace.util.Quantity,
         ):
-            origin = grid_indexing.origin_compute()
-            shape = grid_indexing.max_shape
             # Define the memory specification required
             # Those can be re-used as they are read-only descriptors
-            full_size_xyz_halo_spec = grid_indexing.get_quantity_halo_spec(
-                shape,
-                origin,
+            full_size_xyz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
-                backend=backend,
             )
-            full_size_xyiz_halo_spec = grid_indexing.get_quantity_halo_spec(
-                shape,
-                origin,
+            full_size_xyiz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
-                backend=backend,
             )
-            full_size_xiyz_halo_spec = grid_indexing.get_quantity_halo_spec(
-                shape,
-                origin,
+            full_size_xiyz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_INTERFACE_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
-                backend=backend,
             )
-            full_size_xyzi_halo_spec = grid_indexing.get_quantity_halo_spec(
-                shape,
-                origin,
+            full_size_xyzi_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_INTERFACE_DIM],
                 n_halo=grid_indexing.n_halo,
-                backend=backend,
             )
-            full_size_xiyiz_halo_spec = grid_indexing.get_quantity_halo_spec(
-                shape,
-                origin,
+            full_size_xiyiz_halo_spec = quantity_factory.get_quantity_halo_spec(
                 dims=[fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
                 n_halo=grid_indexing.n_halo,
-                backend=backend,
             )
 
             # Build the HaloUpdater. We could build one updater per specification group
@@ -336,12 +319,9 @@ class AcousticDynamics:
                 ["heat_source"],
             )
             if grid_indexing.domain[0] == grid_indexing.domain[1]:
-                full_3Dfield_2pts_halo_spec = grid_indexing.get_quantity_halo_spec(
-                    shape,
-                    origin,
+                full_3Dfield_2pts_halo_spec = quantity_factory.get_quantity_halo_spec(
                     dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_INTERFACE_DIM],
                     n_halo=2,
-                    backend=backend,
                 )
                 self.pkc = WrappedHaloUpdater(
                     comm.get_scalar_halo_updater([full_3Dfield_2pts_halo_spec]),
@@ -626,7 +606,7 @@ class AcousticDynamics:
         self._halo_updaters = AcousticDynamics._HaloUpdaters(
             comm,
             grid_indexing,
-            stencil_factory.backend,
+            quantity_factory,
             state,
             cappa=self.cappa,
             gz=self._gz,

--- a/fv3core/pace/fv3core/stencils/dyn_core.py
+++ b/fv3core/pace/fv3core/stencils/dyn_core.py
@@ -498,22 +498,6 @@ class AcousticDynamics:
             )
         )
 
-        # TODO (floriand): Due to DaCe VRAM pooling creating a memory
-        # leak with the usage pattern of those two fields
-        # We use the C_SW internal to workaround it e.g.:
-        #  - self.cgrid_shallow_water_lagrangian_dynamics.delpc
-        #  - self.cgrid_shallow_water_lagrangian_dynamics.ptc
-        # DaCe has already a fix on their side and it awaits release
-        # issue
-        # self.delpc = utils.make_storage_from_shape(
-        #     grid_indexing.domain_full(add=(1, 1, 1)),
-        #     backend=stencil_factory.backend,
-        # )
-        # self.ptc = utils.make_storage_from_shape(
-        #     grid_indexing.domain_full(add=(1, 1, 1)),
-        #     backend=stencil_factory.backend,
-        # )
-
         self.cgrid_shallow_water_lagrangian_dynamics = CGridShallowWaterDynamics(
             stencil_factory,
             quantity_factory=quantity_factory,
@@ -803,6 +787,13 @@ class AcousticDynamics:
                 self.update_geopotential_height_on_c_grid(
                     self._zs, self._ut, self._vt, self._gz, self._ws3, dt2
                 )
+                # TODO (floriand): Due to DaCe VRAM pooling creating a memory
+                # leak with the usage pattern of those two fields
+                # We use the C_SW internal to workaround it e.g.:
+                #  - self.cgrid_shallow_water_lagrangian_dynamics.delpc
+                #  - self.cgrid_shallow_water_lagrangian_dynamics.ptc
+                # DaCe has already a fix on their side and it awaits release
+                # issue
                 self.riem_solver_c(
                     dt2,
                     self.cappa,

--- a/fv3core/pace/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/pace/fv3core/stencils/fv_dynamics.py
@@ -296,7 +296,7 @@ class DynamicalCore:
             self.config.nf_omega,
         )
         self._cubed_to_latlon = CubedToLatLon(
-            state, stencil_factory, grid_data, config.c2l_ord, comm
+            state, stencil_factory, quantity_factory, grid_data, config.c2l_ord, comm
         )
         self._cappa = self.acoustic_dynamics.cappa
 
@@ -320,12 +320,9 @@ class DynamicalCore:
             checkpointer=checkpointer,
         )
 
-        full_xyz_spec = grid_indexing.get_quantity_halo_spec(
-            grid_indexing.domain_full(add=(1, 1, 1)),
-            grid_indexing.origin_compute(),
+        full_xyz_spec = quantity_factory.get_quantity_halo_spec(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             n_halo=grid_indexing.n_halo,
-            backend=stencil_factory.backend,
         )
         self._omega_halo_updater = WrappedHaloUpdater(
             comm.get_scalar_halo_updater([full_xyz_spec]), state, ["omga"], comm=comm

--- a/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
@@ -259,12 +259,9 @@ class TracerAdvection:
         # self._cmax_2 = stencil_factory.from_origin_domain(cmax_stencil2)
 
         # Setup halo updater for tracers
-        tracer_halo_spec = grid_indexing.get_quantity_halo_spec(
-            grid_indexing.domain_full(add=(1, 1, 1)),
-            grid_indexing.origin_compute(),
+        tracer_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             n_halo=utils.halo,
-            backend=stencil_factory.backend,
         )
         self._tracers_halo_updater = WrappedHaloUpdater(
             comm.get_scalar_halo_updater([tracer_halo_spec] * self._tracer_count),

--- a/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/pace/fv3core/stencils/tracer_2d_1l.py
@@ -253,10 +253,6 @@ class TracerAdvection:
             externals=local_axis_offsets,
         )
         self.finite_volume_transport: FiniteVolumeTransport = transport
-        # If use AllReduce, will need something like this:
-        # self._tmp_cmax = utils.make_storage_from_shape(shape, origin)
-        # self._cmax_1 = stencil_factory.from_origin_domain(cmax_stencil1)
-        # self._cmax_2 = stencil_factory.from_origin_domain(cmax_stencil2)
 
         # Setup halo updater for tracers
         tracer_halo_spec = quantity_factory.get_quantity_halo_spec(

--- a/fv3core/tests/savepoint/translate/translate_cubedtolatlon.py
+++ b/fv3core/tests/savepoint/translate/translate_cubedtolatlon.py
@@ -49,6 +49,7 @@ class TranslateCubedToLatLon(ParallelTranslate2Py):
         self._cubed_to_latlon = CubedToLatLon(
             state=state_dict,
             stencil_factory=self.stencil_factory,
+            quantity_factory=self.grid.quantity_factory,
             grid_data=self.grid.grid_data,
             order=self.namelist.c2l_ord,
             comm=communicator,

--- a/physics/pace/physics/stencils/microphysics.py
+++ b/physics/pace/physics/stencils/microphysics.py
@@ -10,13 +10,13 @@ except ModuleNotFoundError:
     cp = None
 from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval, sqrt
 
-import pace.dsl.gt4py_utils as utils
 import pace.physics.functions.microphysics_funcs as functions
 import pace.util
 import pace.util.constants as constants
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
 from pace.dsl.typing import Float, FloatField, FloatFieldIJ, Int
+from pace.util import X_DIM, Y_DIM, Z_DIM
 from pace.util.grid import GridData
 
 from .._config import PhysicsConfig
@@ -1897,6 +1897,7 @@ class Microphysics:
     def __init__(
         self,
         stencil_factory: StencilFactory,
+        quantity_factory: pace.util.QuantityFactory,
         grid_data: GridData,
         namelist: PhysicsConfig,
     ):
@@ -1939,56 +1940,54 @@ class Microphysics:
         self._use_ccn = False if self.namelist.prog_ccn else True
         self._area = grid_data.area
 
-        def make_storage(**kwargs):
-            return utils.make_storage_from_shape(
-                shape, origin=origin, backend=stencil_factory.backend, **kwargs
-            )
+        def make_quantity(**kwargs):
+            return quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
 
-        self._rain = make_storage()
-        self._graupel = make_storage()
-        self._ice = make_storage()
-        self._snow = make_storage()
+        self._rain = make_quantity()
+        self._graupel = make_quantity()
+        self._ice = make_quantity()
+        self._snow = make_quantity()
 
-        self._h_var = make_storage()
-        self._rh_adj = make_storage()
-        self._rh_rain = make_storage()
+        self._h_var = make_quantity()
+        self._rh_adj = make_quantity()
+        self._rh_rain = make_quantity()
 
-        self._qn = make_storage()
-        self._qaz = make_storage()
-        self._qgz = make_storage()
-        self._qiz = make_storage()
-        self._qlz = make_storage()
-        self._qrz = make_storage()
-        self._qsz = make_storage()
-        self._qvz = make_storage()
-        self._den = make_storage()
-        self._denfac = make_storage()
-        self._tz = make_storage()
-        self._qa0 = make_storage()
-        self._qg0 = make_storage()
-        self._qi0 = make_storage()
-        self._ql0 = make_storage()
-        self._qr0 = make_storage()
-        self._qs0 = make_storage()
-        self._qv0 = make_storage()
-        self._t0 = make_storage()
-        self._dp0 = make_storage()
-        self._den0 = make_storage()
-        self._dz0 = make_storage()
-        self._u0 = make_storage()
-        self._v0 = make_storage()
-        self._dz1 = make_storage()
-        self._dp1 = make_storage()
-        self._p1 = make_storage()
-        self._u1 = make_storage()
-        self._v1 = make_storage()
-        self._m1 = make_storage()
-        self._vtgz = make_storage()
-        self._vtrz = make_storage()
-        self._vtsz = make_storage()
-        self._ccn = make_storage()
-        self._c_praut = make_storage()
-        self._m1_sol = make_storage()
+        self._qn = make_quantity()
+        self._qaz = make_quantity()
+        self._qgz = make_quantity()
+        self._qiz = make_quantity()
+        self._qlz = make_quantity()
+        self._qrz = make_quantity()
+        self._qsz = make_quantity()
+        self._qvz = make_quantity()
+        self._den = make_quantity()
+        self._denfac = make_quantity()
+        self._tz = make_quantity()
+        self._qa0 = make_quantity()
+        self._qg0 = make_quantity()
+        self._qi0 = make_quantity()
+        self._ql0 = make_quantity()
+        self._qr0 = make_quantity()
+        self._qs0 = make_quantity()
+        self._qv0 = make_quantity()
+        self._t0 = make_quantity()
+        self._dp0 = make_quantity()
+        self._den0 = make_quantity()
+        self._dz0 = make_quantity()
+        self._u0 = make_quantity()
+        self._v0 = make_quantity()
+        self._dz1 = make_quantity()
+        self._dp1 = make_quantity()
+        self._p1 = make_quantity()
+        self._u1 = make_quantity()
+        self._v1 = make_quantity()
+        self._m1 = make_quantity()
+        self._vtgz = make_quantity()
+        self._vtrz = make_quantity()
+        self._vtsz = make_quantity()
+        self._ccn = make_quantity()
+        self._c_praut = make_quantity()
+        self._m1_sol = make_quantity()
 
         self._so3 = 7.0 / 3.0
         self._zs = 0.0

--- a/physics/pace/physics/stencils/microphysics.py
+++ b/physics/pace/physics/stencils/microphysics.py
@@ -1910,17 +1910,8 @@ class Microphysics:
         self.namelist = namelist
         # In orchestration mode, we pass the device memory
         # TODO: turn arrays in setupm into a dataclass, or inidivudal scalars
-        if (
-            stencil_factory.config.is_gpu_backend
-            and stencil_factory.config.dace_config.is_dace_orchestrated()
-        ):
-            self.gfdl_cloud_microphys_init(namelist.dt_atmos, cp)
-        else:
-            self.gfdl_cloud_microphys_init(namelist.dt_atmos, np)
         # [TODO]: many of the "constants" come from namelist, needs to be updated
         grid_indexing = stencil_factory.grid_indexing
-        origin = grid_indexing.origin_compute()
-        shape = grid_indexing.domain_full(add=(1, 1, 1))
 
         self._hydrostatic = self.namelist.hydrostatic
         self._kke = grid_indexing.domain[2] - 1
@@ -1988,6 +1979,8 @@ class Microphysics:
         self._ccn = make_quantity()
         self._c_praut = make_quantity()
         self._m1_sol = make_quantity()
+
+        self.gfdl_cloud_microphys_init(namelist.dt_atmos, self._m1_sol.np)
 
         self._so3 = 7.0 / 3.0
         self._zs = 0.0

--- a/physics/pace/physics/stencils/physics.py
+++ b/physics/pace/physics/stencils/physics.py
@@ -4,7 +4,7 @@ import gt4py.gtscript as gtscript
 from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, exp, interval, log
 from typing_extensions import Literal
 
-import pace.dsl.gt4py_utils as utils
+import pace.util
 import pace.util.constants as constants
 from pace.dsl.dace.orchestration import orchestrate
 from pace.dsl.stencil import StencilFactory
@@ -13,6 +13,7 @@ from pace.physics.physics_state import PhysicsState
 from pace.physics.stencils.get_phi_fv3 import get_phi_fv3
 from pace.physics.stencils.get_prs_fv3 import get_prs_fv3
 from pace.physics.stencils.microphysics import Microphysics
+from pace.util import X_DIM, Y_DIM, Z_DIM
 from pace.util.grid import GridData
 
 from .._config import PhysicsConfig
@@ -196,6 +197,7 @@ class Physics:
     def __init__(
         self,
         stencil_factory: StencilFactory,
+        quantity_factory: pace.util.QuantityFactory,
         grid_data: GridData,
         namelist: PhysicsConfig,
         active_packages: List[Literal[PHYSICS_PACKAGES]],
@@ -207,22 +209,18 @@ class Physics:
         )
 
         grid_indexing = stencil_factory.grid_indexing
-        origin = grid_indexing.origin_compute()
-        shape = grid_indexing.domain_full(add=(1, 1, 1))
         self._setup_statein()
         self._ptop = grid_data.ptop
         self._pktop = (self._ptop / self._p00) ** constants.KAPPA
         self._pk0inv = (1.0 / self._p00) ** constants.KAPPA
 
-        def make_storage():
-            return utils.make_storage_from_shape(
-                shape, origin=origin, backend=stencil_factory.backend
-            )
+        def make_quantity():
+            return quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
 
-        self._prsik = make_storage()
-        self._dm3d = make_storage()
-        self._del_gz = make_storage()
-        self._full_zero_storage = make_storage()
+        self._prsik = make_quantity()
+        self._dm3d = make_quantity()
+        self._del_gz = make_quantity()
+        self._full_zero = make_quantity()
         self._get_prs_fv3 = stencil_factory.from_origin_domain(
             func=get_prs_fv3,
             origin=grid_indexing.origin_full(),
@@ -259,7 +257,7 @@ class Physics:
                 )
             )
             self._microphysics = Microphysics(
-                stencil_factory, grid_data, namelist=namelist
+                stencil_factory, quantity_factory, grid_data, namelist=namelist
             )
         else:
             self._do_microphysics = False

--- a/physics/pace/physics/stencils/physics.py
+++ b/physics/pace/physics/stencils/physics.py
@@ -220,7 +220,6 @@ class Physics:
         self._prsik = make_quantity()
         self._dm3d = make_quantity()
         self._del_gz = make_quantity()
-        self._full_zero = make_quantity()
         self._get_prs_fv3 = stencil_factory.from_origin_domain(
             func=get_prs_fv3,
             origin=grid_indexing.origin_full(),

--- a/physics/tests/savepoint/translate/translate_fv_update_phys.py
+++ b/physics/tests/savepoint/translate/translate_fv_update_phys.py
@@ -170,6 +170,7 @@ class TranslateFVUpdatePhys(ParallelPhysicsTranslate2Py):
         state = DycoreState(**inputs)
         self._base.compute_func = ApplyPhysicsToDycore(
             self.stencil_factory,
+            self.grid.quantity_factory,
             self.grid.grid_data,
             self.namelist,
             communicator,

--- a/physics/tests/savepoint/translate/translate_gfs_physics_driver.py
+++ b/physics/tests/savepoint/translate/translate_gfs_physics_driver.py
@@ -137,6 +137,7 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
         )
         physics = Physics(
             self.stencil_factory,
+            self.grid.quantity_factory,
             self.grid.grid_data,
             self.namelist,
             active_packages=active_packages,

--- a/physics/tests/savepoint/translate/translate_microphysics.py
+++ b/physics/tests/savepoint/translate/translate_microphysics.py
@@ -91,7 +91,7 @@ class TranslateMicroph(TranslatePhysicsFortranData2Py):
             active_packages=["microphysics"],
         )
         microphysics = Microphysics(
-            self.stencil_factory, self.grid.grid_data, self.namelist
+            self.stencil_factory, quantity_factory, self.grid.grid_data, self.namelist
         )
         microph_state = physics_state.microphysics
         microphysics(microph_state, timestep=Float(self.namelist.dt_atmos))

--- a/stencils/pace/stencils/c2l_ord.py
+++ b/stencils/pace/stencils/c2l_ord.py
@@ -1,11 +1,11 @@
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
 import pace.dsl.gt4py_utils as utils
+import pace.util
 from pace import fv3core
 from pace.dsl.dace.wrapped_halo_exchange import WrappedHaloUpdater
 from pace.dsl.stencil import StencilFactory
 from pace.dsl.typing import FloatField, FloatFieldIJ
-from pace.util import CubedSphereCommunicator
 from pace.util.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from pace.util.grid import GridData
 
@@ -106,9 +106,10 @@ class CubedToLatLon:
         self,
         state: fv3core.DycoreState,
         stencil_factory: StencilFactory,
+        quantity_factory: pace.util.QuantityFactory,
         grid_data: GridData,
         order: int,
-        comm: CubedSphereCommunicator,
+        comm: pace.util.CubedSphereCommunicator,
     ):
         """
         Initializes stencils to use either 2nd or 4th order of interpolation
@@ -145,19 +146,13 @@ class CubedToLatLon:
 
         origin = grid_indexing.origin_compute()
         shape = grid_indexing.max_shape
-        full_size_xyiz_halo_spec = grid_indexing.get_quantity_halo_spec(
-            shape,
-            origin,
+        full_size_xyiz_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[X_DIM, Y_INTERFACE_DIM, Z_DIM],
             n_halo=grid_indexing.n_halo,
-            backend=stencil_factory.backend,
         )
-        full_size_xiyz_halo_spec = grid_indexing.get_quantity_halo_spec(
-            shape,
-            origin,
+        full_size_xiyz_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[X_INTERFACE_DIM, Y_DIM, Z_DIM],
             n_halo=grid_indexing.n_halo,
-            backend=stencil_factory.backend,
         )
         self.u__v = WrappedHaloUpdater(
             comm.get_vector_halo_updater(

--- a/stencils/pace/stencils/fv_update_phys.py
+++ b/stencils/pace/stencils/fv_update_phys.py
@@ -84,6 +84,7 @@ class ApplyPhysicsToDycore:
     def __init__(
         self,
         stencil_factory: StencilFactory,
+        quantity_factory: pace.util.QuantityFactory,
         grid_data: GridData,
         namelist,
         comm: pace.util.CubedSphereCommunicator,
@@ -113,17 +114,18 @@ class ApplyPhysicsToDycore:
             stencil_factory, comm.partitioner.tile, comm.rank, namelist, grid_info
         )
         self._do_cubed_to_latlon = CubedToLatLon(
-            state, stencil_factory, grid_data, order=namelist.c2l_ord, comm=comm
+            state,
+            stencil_factory,
+            quantity_factory=quantity_factory,
+            grid_data=grid_data,
+            order=namelist.c2l_ord,
+            comm=comm,
         )
-        self.origin = grid_indexing.origin_compute()
-        self.extent = grid_indexing.domain_compute()
+        origin = grid_indexing.origin_compute()
         shape = grid_indexing.max_shape
-        full_3Dfield_1pts_halo_spec = grid_indexing.get_quantity_halo_spec(
-            shape,
-            self.origin,
+        full_3Dfield_1pts_halo_spec = quantity_factory.get_quantity_halo_spec(
             dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
             n_halo=1,
-            backend=stencil_factory.backend,
         )
         self._udt_halo_updater = WrappedHaloUpdater(
             self.comm.get_scalar_halo_updater([full_3Dfield_1pts_halo_spec]),
@@ -137,10 +139,10 @@ class ApplyPhysicsToDycore:
         )
         # TODO: check if we actually need surface winds
         self._u_srf = utils.make_storage_from_shape(
-            shape[0:2], origin=self.origin, backend=stencil_factory.backend
+            shape[0:2], origin=origin, backend=stencil_factory.backend
         )
         self._v_srf = utils.make_storage_from_shape(
-            shape[0:2], origin=self.origin, backend=stencil_factory.backend
+            shape[0:2], origin=origin, backend=stencil_factory.backend
         )
 
     def __call__(

--- a/stencils/pace/stencils/testing/grid.py
+++ b/stencils/pace/stencils/testing/grid.py
@@ -443,12 +443,9 @@ class Grid:
         dims=[pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM],
     ) -> QuantityHaloSpec:
         """Build memory specifications for the halo update."""
-        return self.grid_indexing.get_quantity_halo_spec(
-            shape,
-            origin,
+        return self.quantity_factory.get_quantity_halo_spec(
             dims=dims,
             n_halo=halo_points,
-            backend=self.backend,
         )
 
     @property

--- a/stencils/pace/stencils/testing/translate_update_dwind_phys.py
+++ b/stencils/pace/stencils/testing/translate_update_dwind_phys.py
@@ -26,6 +26,7 @@ class TranslateUpdateDWindsPhys(TranslatePhysicsFortranData2Py):
         partitioner = pace.util.TilePartitioner(self.namelist.layout)
         self.compute_func = AGrid2DGridPhysics(
             self.stencil_factory,
+            self.grid.quantity_factory,
             partitioner,
             self.grid.rank,
             self.namelist,

--- a/stencils/pace/stencils/update_atmos_state.py
+++ b/stencils/pace/stencils/update_atmos_state.py
@@ -261,8 +261,6 @@ class UpdateAtmosphereState:
 
         grid_indexing = stencil_factory.grid_indexing
         self.namelist = namelist
-        origin = grid_indexing.origin_compute()
-        shape = grid_indexing.domain_full(add=(1, 1, 1))
         self._rdt = 1.0 / Float(self.namelist.dt_atmos)
 
         self._prepare_tendencies_and_update_tracers = (
@@ -273,7 +271,6 @@ class UpdateAtmosphereState:
             )
         )
 
-        dims = [pace.util.X_DIM, pace.util.Y_DIM, pace.util.Z_DIM]
         self._fill_GFS_delp = stencil_factory.from_origin_domain(
             fill_gfs_delp,
             origin=grid_indexing.origin_full(),
@@ -282,6 +279,7 @@ class UpdateAtmosphereState:
 
         self._apply_physics_to_dycore = ApplyPhysicsToDycore(
             stencil_factory,
+            quantity_factory,
             grid_data,
             self.namelist,
             comm,

--- a/stencils/pace/stencils/update_dwind_phys.py
+++ b/stencils/pace/stencils/update_dwind_phys.py
@@ -1,10 +1,10 @@
 from gt4py.gtscript import PARALLEL, computation, interval
 
-import pace.dsl.gt4py_utils as utils
+import pace.util
 from pace.dsl.dace import orchestrate
 from pace.dsl.stencil import StencilFactory
 from pace.dsl.typing import FloatField, FloatFieldI, FloatFieldIJ
-from pace.util import TilePartitioner
+from pace.util import X_DIM, Y_DIM, Z_DIM
 from pace.util.grid import DriverGridData
 
 
@@ -157,7 +157,8 @@ class AGrid2DGridPhysics:
     def __init__(
         self,
         stencil_factory: StencilFactory,
-        partitioner: TilePartitioner,
+        quantity_factory: pace.util.QuantityFactory,
+        partitioner: pace.util.TilePartitioner,
         rank: int,
         namelist,
         grid_info: DriverGridData,
@@ -186,21 +187,21 @@ class AGrid2DGridPhysics:
         self.west_edge = grid_indexing.west_edge
         self.east_edge = grid_indexing.east_edge
 
-        def make_storage():
-            return utils.make_storage_from_shape(shape, backend=stencil_factory.backend)
+        def make_quantity():
+            return quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
 
-        self._ue_1 = make_storage()
-        self._ue_2 = make_storage()
-        self._ue_3 = make_storage()
-        self._ut_1 = make_storage()
-        self._ut_2 = make_storage()
-        self._ut_3 = make_storage()
-        self._ve_1 = make_storage()
-        self._ve_2 = make_storage()
-        self._ve_3 = make_storage()
-        self._vt_1 = make_storage()
-        self._vt_2 = make_storage()
-        self._vt_3 = make_storage()
+        self._ue_1 = make_quantity()
+        self._ue_2 = make_quantity()
+        self._ue_3 = make_quantity()
+        self._ut_1 = make_quantity()
+        self._ut_2 = make_quantity()
+        self._ut_3 = make_quantity()
+        self._ve_1 = make_quantity()
+        self._ve_2 = make_quantity()
+        self._ve_3 = make_quantity()
+        self._vt_1 = make_quantity()
+        self._vt_2 = make_quantity()
+        self._vt_3 = make_quantity()
 
         self._update_dwind_prep_stencil = stencil_factory.from_origin_domain(
             update_dwind_prep_stencil,

--- a/tests/main/physics/test_integration.py
+++ b/tests/main/physics/test_integration.py
@@ -61,7 +61,11 @@ def setup_physics():
     )
     grid_data = pace.util.grid.GridData.new_from_metric_terms(metric_terms)
     physics = pace.physics.Physics(
-        stencil_factory, grid_data, physics_config, active_packages=["microphysics"]
+        stencil_factory,
+        quantity_factory,
+        grid_data,
+        physics_config,
+        active_packages=["microphysics"],
     )
     physics_state = pace.physics.PhysicsState.init_zeros(
         quantity_factory, active_packages=["microphysics"]

--- a/util/pace/util/initialization/allocator.py
+++ b/util/pace/util/initialization/allocator.py
@@ -1,6 +1,8 @@
-from typing import Callable, Sequence
+from typing import Callable, Optional, Sequence
 
 import numpy as np
+
+from pace.util.halo_data_transformer import QuantityHaloSpec
 
 from .._optional_imports import gt4py
 from ..constants import SPATIAL_DIMS, X_DIMS, Y_DIMS, Z_DIMS
@@ -117,3 +119,40 @@ class QuantityFactory:
         except TypeError:
             data = allocator(shape, dtype=dtype)
         return Quantity(data, dims=dims, units=units, origin=origin, extent=extent)
+
+    def get_quantity_halo_spec(
+        self, dims: Sequence[str], n_halo: Optional[int] = None, dtype: type = float
+    ) -> QuantityHaloSpec:
+        """Build memory specifications for the halo update.
+
+        Args:
+            dims: dimensionality of the data
+            n_halo: number of halo points to update, defaults to self.n_halo
+            dtype: data type of the data
+            backend: gt4py backend to use
+        """
+
+        # TEMPORARY: we do a nasty temporary allocation here to read in the hardware
+        # memory layout. Further work in GT4PY will allow for deferred allocation
+        # which will give access to those information while making sure
+        # we don't allocate
+        # Refactor is filed in ticket DSL-820
+
+        temp_quantity = self.zeros(dims=dims, units="", dtype=dtype)
+
+        if n_halo is None:
+            n_halo = self.sizer.n_halo
+
+        spec = QuantityHaloSpec(
+            n_halo,
+            temp_quantity.data.strides,
+            temp_quantity.data.itemsize,
+            temp_quantity.data.shape,
+            temp_quantity.metadata.origin,
+            temp_quantity.metadata.extent,
+            temp_quantity.metadata.dims,
+            temp_quantity.np,
+            temp_quantity.metadata.dtype,
+        )
+
+        return spec


### PR DESCRIPTION
## Purpose

This PR refactors all usage of storages to Quantity, other than in test code.

## Code changes:

- get_quantity_halo_spec method is moved from GridIndexing to QuantityFactory
- all internal temporaries in physics, fv3core, and coupling code are now Quantity instead of storage

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] For each public change and fix in `pace-util`, HISTORY has been updated
- [x] Unit tests are added or updated for non-stencil code changes

