### PR TITLE
add safety checks for guarantees on the state during runs

### DIFF
--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -518,7 +518,7 @@ class Driver:
         self._time_run = self.config.start_time
 
         self.safety_checker = SafetyChecker()
-        SafetyChecker.register_variable("ua", -200, 200)
+        SafetyChecker.register_variable("ua", -200, 200, compute_domain_only=True)
 
     def _update_driver_config_with_communicator(
         self, communicator: CubedSphereCommunicator

--- a/driver/pace/driver/driver.py
+++ b/driver/pace/driver/driver.py
@@ -123,7 +123,7 @@ class DriverConfig:
     pair_debug: bool = False
     output_initial_state: bool = False
     output_frequency: int = 1
-    safety_check_frequency: int = 1
+    safety_check_frequency: Optional[int] = None
 
     @functools.cached_property
     def timestep(self) -> timedelta:
@@ -559,7 +559,10 @@ class Driver:
         self.time += self.config.timestep
         if ((step + 1) % self.config.output_frequency) == 0:
             self.diagnostics.store(time=self.time, state=self.state)
-        if ((step + 1) % self.config.safety_check_frequency) == 0:
+        if (
+            self.config.safety_check_frequency
+            and ((step + 1) % self.config.safety_check_frequency) == 0
+        ):
             self.safety_checker.check_state(self.state.dycore_state)
         self.config.restart_config.write_intermediate_if_enabled(
             state=self.state,

--- a/driver/pace/driver/safety_checks.py
+++ b/driver/pace/driver/safety_checks.py
@@ -1,36 +1,84 @@
 from typing import ClassVar, Dict, Optional, Tuple
 
 from pace.fv3core.initialization.dycore_state import DycoreState
+from pace.util.quantity import Quantity
 
 
 class SafetyChecker:
-    checks: ClassVar[Dict[str, Tuple[Optional[int], Optional[int]]]] = {}
+    """Safety-Checker that checks the state for sanity of variables
 
-    def __init__(self) -> None:
-        pass
+    Raises:
+        NotImplementedError: Doubly-registered variables
+        NotImplementedError: Variables not in the state
+        RuntimeError: Variables outside the specified bounds
+    """
+
+    checks: ClassVar[Dict[str, Tuple[Optional[int], Optional[int], bool]]] = {}
 
     @classmethod
-    def register_variable(cls, name, minimum_value=None, maximum_value=None):
+    def register_variable(
+        cls,
+        name: str,
+        minimum_value: Optional[int] = None,
+        maximum_value: Optional[int] = None,
+        compute_domain_only: bool = False,
+    ):
+        """Register a variable in the checker
+
+        Args:
+            name (str): name of the variable in the dycore state
+            minimum_value (Optional[int], optional): Minimum value if specified. Defaults to None.
+            maximum_value (Optional[int], optional): Maximum value if specified. Defaults to None.
+            compute_domain_only (bool, optional): If evaluation should only happen on the compute or the entire domain. Defaults to False.
+
+        Raises:
+            NotImplementedError: If variables are doubly-registered
+        """
         if name in cls.checks:
             raise NotImplementedError("Can only register variables once")
         else:
-            cls.checks[name] = (minimum_value, maximum_value)
+            cls.checks[name] = (minimum_value, maximum_value, compute_domain_only)
 
     @classmethod
     def clear_all_checks(cls):
+        """Clear all the registered checks"""
         cls.checks.clear()
 
     def check_state(self, state: DycoreState):
+        """check the given dycore state with all the registered constraints
+
+        Args:
+            state (DycoreState): State to check
+
+        Raises:
+            NotImplementedError: If one of the registered variables are not in the state
+            RuntimeError: If one of the variables exceeds its specified bounds
+        """
         for variable, bounds in self.checks.items():
             try:
-                var = state.__getattribute__(variable)
+                var: Quantity = state.__getattribute__(variable)
             except AttributeError:
                 raise NotImplementedError("Variable is not in the state")
-            if bounds[0] and var.data.min() < bounds[0]:
+            if bounds[2]:
+                min_value = var.data[
+                    var.origin[0] : var.origin[0] + var.extent[0],
+                    var.origin[1] : var.origin[1] + var.extent[1],
+                    var.origin[2] : var.origin[2] + var.extent[2],
+                ].min()
+                max_value = var.data[
+                    var.origin[0] : var.origin[0] + var.extent[0],
+                    var.origin[1] : var.origin[1] + var.extent[1],
+                    var.origin[2] : var.origin[2] + var.extent[2],
+                ].max()
+            else:
+                min_value = var.data.min()
+                max_value = var.data.max()
+
+            if bounds[0] and min_value < bounds[0]:
                 raise RuntimeError(
-                    f"Variable {variable} is outside of its specified bounds: {bounds[0]} specified, {var.data.min()} found"
+                    f"Variable {variable} is outside of its specified bounds: {bounds[0]} specified, {min_value} found"
                 )
-            if bounds[1] and var.data.max() > bounds[1]:
+            if bounds[1] and max_value > bounds[1]:
                 raise RuntimeError(
-                    f"Variable {variable} is outside of its specified bounds: {bounds[1]} specified, {var.data.max()} found"
+                    f"Variable {variable} is outside of its specified bounds: {bounds[1]} specified, {max_value} found"
                 )

--- a/driver/pace/driver/safety_checks.py
+++ b/driver/pace/driver/safety_checks.py
@@ -27,9 +27,12 @@ class SafetyChecker:
 
         Args:
             name (str): name of the variable in the dycore state
-            minimum_value (Optional[int], optional): Minimum value if specified. Defaults to None.
-            maximum_value (Optional[int], optional): Maximum value if specified. Defaults to None.
-            compute_domain_only (bool, optional): If evaluation should only happen on the compute or the entire domain. Defaults to False.
+            minimum_value (Optional[int], optional): Minimum value if specified.
+                Defaults to None.
+            maximum_value (Optional[int], optional): Maximum value if specified.
+                Defaults to None.
+            compute_domain_only (bool, optional): If evaluation should only happen
+                on the compute or the entire domain. Defaults to False.
 
         Raises:
             NotImplementedError: If variables are doubly-registered
@@ -76,9 +79,11 @@ class SafetyChecker:
 
             if bounds[0] and min_value < bounds[0]:
                 raise RuntimeError(
-                    f"Variable {variable} is outside of its specified bounds: {bounds[0]} specified, {min_value} found"
+                    f"Variable {variable} is outside of its specified bounds: \
+                    {bounds[0]} specified, {min_value} found"
                 )
             if bounds[1] and max_value > bounds[1]:
                 raise RuntimeError(
-                    f"Variable {variable} is outside of its specified bounds: {bounds[1]} specified, {max_value} found"
+                    f"Variable {variable} is outside of its specified bounds: \
+                    {bounds[1]} specified, {max_value} found"
                 )

--- a/driver/pace/driver/safety_checks.py
+++ b/driver/pace/driver/safety_checks.py
@@ -1,0 +1,36 @@
+from typing import ClassVar, Dict, Optional, Tuple
+
+from pace.fv3core.initialization.dycore_state import DycoreState
+
+
+class SafetyChecker:
+    checks: ClassVar[Dict[str, Tuple[Optional[int], Optional[int]]]] = {}
+
+    def __init__(self) -> None:
+        pass
+
+    @classmethod
+    def register_variable(cls, name, minimum_value=None, maximum_value=None):
+        if name in cls.checks:
+            raise NotImplementedError("Can only register variables once")
+        else:
+            cls.checks[name] = (minimum_value, maximum_value)
+
+    @classmethod
+    def clear_all_checks(cls):
+        cls.checks.clear()
+
+    def check_state(self, state: DycoreState):
+        for variable, bounds in self.checks.items():
+            try:
+                var = state.__getattribute__(variable)
+            except AttributeError:
+                raise NotImplementedError("Variable is not in the state")
+            if bounds[0] and var.data.min() < bounds[0]:
+                raise RuntimeError(
+                    f"Variable {variable} is outside of its specified bounds: {bounds[0]} specified, {var.data.min()} found"
+                )
+            if bounds[1] and var.data.max() > bounds[1]:
+                raise RuntimeError(
+                    f"Variable {variable} is outside of its specified bounds: {bounds[1]} specified, {var.data.max()} found"
+                )

--- a/tests/main/driver/test_safety_checks.py
+++ b/tests/main/driver/test_safety_checks.py
@@ -1,0 +1,62 @@
+import unittest.mock
+
+import pytest
+
+from pace.driver.safety_checks import SafetyChecker
+
+
+def test_register_variable():
+    SafetyChecker.clear_all_checks()
+    SafetyChecker.register_variable("u", minimum_value=10)
+    assert len(SafetyChecker.checks) == 1
+
+
+def test_double_register():
+    SafetyChecker.clear_all_checks()
+    SafetyChecker.register_variable("u", minimum_value=10)
+    with pytest.raises(NotImplementedError):
+        SafetyChecker.register_variable("u", maximum_value=20)
+
+
+def test_check_state():
+    SafetyChecker.clear_all_checks()
+    SafetyChecker.register_variable("u", minimum_value=10, maximum_value=20)
+    checker = SafetyChecker()
+    u = unittest.mock.MagicMock()
+    u.data.min.return_value = 11
+    u.data.max.return_value = 19
+    dycore_state = unittest.mock.MagicMock(u=u)
+    checker.check_state(dycore_state)
+
+
+def test_check_state_failing_min():
+    SafetyChecker.clear_all_checks()
+    SafetyChecker.register_variable("u", minimum_value=10)
+    checker = SafetyChecker()
+    u = unittest.mock.MagicMock()
+    u.data.min.return_value = 9
+    dycore_state = unittest.mock.MagicMock(u=u)
+    with pytest.raises(RuntimeError):
+        checker.check_state(dycore_state)
+
+
+def test_check_state_failing_max():
+    SafetyChecker.clear_all_checks()
+    SafetyChecker.register_variable("u", maximum_value=10)
+    checker = SafetyChecker()
+    u = unittest.mock.MagicMock()
+    u.data.max.return_value = 11
+    dycore_state = unittest.mock.MagicMock(u=u)
+    with pytest.raises(RuntimeError):
+        checker.check_state(dycore_state)
+
+
+def test_variable_not_present():
+    SafetyChecker.clear_all_checks()
+    SafetyChecker.register_variable("v", maximum_value=10)
+    checker = SafetyChecker()
+    u = unittest.mock.MagicMock()
+    u.data.max.return_value = 11
+    dycore_state = unittest.mock.MagicMock(u=u)
+    with pytest.raises(NotImplementedError):
+        checker.check_state(dycore_state)

--- a/tests/main/driver/test_safety_checks.py
+++ b/tests/main/driver/test_safety_checks.py
@@ -1,8 +1,10 @@
 import unittest.mock
 
+import numpy as np
 import pytest
 
 from pace.driver.safety_checks import SafetyChecker
+from pace.util import Quantity
 
 
 def test_register_variable():
@@ -49,6 +51,24 @@ def test_check_state_failing_max():
     dycore_state = unittest.mock.MagicMock(u=u)
     with pytest.raises(RuntimeError):
         checker.check_state(dycore_state)
+
+
+def test_check_state_domain_only():
+    SafetyChecker.clear_all_checks()
+    SafetyChecker.register_variable("u", maximum_value=10, compute_domain_only=True)
+    checker = SafetyChecker()
+    u_data = np.ones((4, 4, 2))
+    u_data[0:1, 0:1, :] = 100
+    u_quantity = Quantity(
+        u_data,
+        ("x", "y", "z"),
+        "unknown",
+        origin=(1, 1, 0),
+        extent=(3, 3, 2),
+        gt4py_backend="numpy",
+    )
+    dycore_state = unittest.mock.MagicMock(u=u_quantity)
+    checker.check_state(dycore_state)
 
 
 def test_variable_not_present():


### PR DESCRIPTION
## Purpose

As per discussion we want a way to test that our state is still sane during runs

## Code changes:

- Added a `SafetyChecker` in the main driver that is called every `safety_check_frequency` in the `_end_of_step_actions` and checks the state for consistency
- Added optional  `safety_check_frequency` to the DriverConfig
- Added `SafetyChecker` that does check on local data
- Added tests for the `SafetyChecker`


## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] Unit tests are added or updated for non-stencil code changes