### PR TITLE
Store grid outputs agrid lat/lon by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,10 +74,6 @@ repos:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
-
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
-    hooks:
     - id: flake8
       name: flake8
       language_version: python3

--- a/driver/pace/driver/diagnostics.py
+++ b/driver/pace/driver/diagnostics.py
@@ -202,6 +202,8 @@ class MonitorDiagnostics(Diagnostics):
         zarr_grid = {
             "lat": grid_data.lat,
             "lon": grid_data.lon,
+            "lon_agrid": grid_data.lon_agrid,
+            "lat_agrid": grid_data.lat_agrid,
         }
         self.monitor.store_constant(zarr_grid)
 

--- a/driver/pace/driver/diagnostics.py
+++ b/driver/pace/driver/diagnostics.py
@@ -51,8 +51,9 @@ class ZSelect:
                 pace.util.Z_DIM or pace.util.Z_INTERFACE_DIM
             ):
                 raise ValueError(
-                    f"z_select only works for state variables with dimension (x, y, z). \
-                        \n {name} has dimension {getattr(state, name).dims}"
+                    f"z_select only works for state variables with dimension \
+                        (x, y, z). \n {name} has \
+                        dimension {getattr(state, name).dims}"
                 )
             var_name = f"{name}_z{self.level}"
             output[var_name] = pace.util.Quantity(

--- a/util/pace/util/boundary.py
+++ b/util/pace/util/boundary.py
@@ -63,7 +63,7 @@ class Boundary:
         return self._slice(specification, interior=False)
 
     def _slice(self, specification: QuantityHaloSpec, interior: bool) -> Tuple[slice]:
-        """Returns a tuple of slices (one per dimensions) indexing the data to be exchange.
+        """Returns a tuple of slices (one per dimensions) for the data to be exchanged.
 
         Args:
             specification: memory information on this halo, including halo size


### PR DESCRIPTION
## Purpose

This PR adds A-grid latitude and longitude to default stored grid for plotting purposes.

## Code changes:

- Add `lat/lon_agrid` to `store_grid`

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://drive.google.com/file/d/1R0nqOxfYnzaSdoYdt8yjx5J482ETI2Ft/view?usp=sharing).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] For each public change and fix in `pace-util`, HISTORY has been updated
- [ ] Unit tests are added or updated for non-stencil code changes
