### PR TITLE
Ignore error if nothing to commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,7 +499,7 @@ jobs:
             git config --global user.name "CircleCI"
             git config --global user.email "ai2cm@allenai.org"
             git -C gh-pages add docs/
-            git -C gh-pages commit -a -m "Docs for $hash"
+            git -C gh-pages commit -a -m "Docs for $hash" || echo "No changes"
             git -C gh-pages push
 
 workflows:


### PR DESCRIPTION
## Purpose

Fix push_docs by ignoring error if there is nothing to commit.

I checked and `git push` returns 0 if there is nothing to push, so this _should_ be all that is needed to avoid the test "failure".