### PR TITLE
Add CircleCI deploy key with write permission

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,6 +488,10 @@ jobs:
           command: |
             . venv/bin/activate
             make docs
+      - add_ssh_keys:
+          fingerprints:
+            - "ed:d1:6a:54:37:66:26:d0:f7:fc:69:a7:c6:89:53:78"
+
       - run:
           name: Move into place
           command: |
@@ -635,6 +639,3 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only:
-                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -639,3 +639,6 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              only:
+                - main

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,6 +21,7 @@ or if you have already cloned the repository:
 
 Pace requires GCC > 9.2, MPI, and Python 3.8 on your system, and CUDA is required to run with a GPU backend.
 You will also need the headers of the boost libraries in your `$PATH` (boost itself does not need to be installed).
+If installed outside the standard header locations, gt4py requires that `$BOOST_ROOT` be set:
 
 .. code-block:: console
 


### PR DESCRIPTION
Uses a new ssh key stored on CircleCI that includes write permission.

Follows https://circleci.com/docs/github-integration/#create-a-github-deploy-key.
